### PR TITLE
Use FULLTEXT index only if *all* columns are TEXT.

### DIFF
--- a/sqlite3_to_mysql/transporter.py
+++ b/sqlite3_to_mysql/transporter.py
@@ -357,7 +357,7 @@ class SQLite3toMySQL:
 
             index_type = "UNIQUE" if int(index["unique"]) == 1 else "INDEX"
 
-            if any(
+            if all(
                 table_columns[index_info["name"]].upper() == "TEXT"
                 for index_info in index_infos
             ):
@@ -381,7 +381,7 @@ class SQLite3toMySQL:
                 for index_info in index_infos:
                     index_length = ""
                     # Limit the max BLOB field index length to 255
-                    if table_columns[index_info["name"]].upper() == "BLOB":
+                    if table_columns[index_info["name"]].upper() in {"TEXT", "BLOB"}:
                         index_length = "({})".format(255)
                     else:
                         suffix = self.COLUMN_LENGTH_PATTERN.search(


### PR DESCRIPTION
Thanks for this tool! I've used it to successfully convert my [Grafana](https://grafana.com/) database to MySQL (with my modification).

The Grafana database contains indexes with both `INT` and `TEXT` columns. MySQL doesn't allow `FULLTEXT` indexes on columns with different types.

You might want to consider removing the `FULLTEXT` support alltogether and default to prefix indexes (`column(255)`), because `FULLTEXT` indexes are not that common and can only be used in specific scenario's/queries (`MATCH() ... AGAINST`).