### PR TITLE
:sparkles: handle generated columns

### DIFF
--- a/sqlite3_to_mysql/sqlite_utils.py
+++ b/sqlite3_to_mysql/sqlite_utils.py
@@ -9,6 +9,7 @@ from sys import version_info
 import six
 from pytimeparse.timeparse import timeparse
 from unidecode import unidecode
+from packaging import version
 
 if version_info.major == 3 and 4 <= version_info.minor <= 6:
     from backports.datetime_fromisoformat import MonkeyPatch  # pylint: disable=E0401
@@ -65,3 +66,13 @@ def convert_date(value):
         raise ValueError(  # pylint: disable=W0707
             "DATE field contains Invalid isoformat string: {}".format(err)
         )
+
+
+def check_sqlite_table_xinfo_support(version_string):
+    """Check for SQLite table_xinfo support."""
+    sqlite_version = version.parse(version_string)
+    if sqlite_version.major > 3 or (
+        sqlite_version.major == 3 and sqlite_version.minor >= 26
+    ):
+        return True
+    return False

--- a/sqlite3_to_mysql/transporter.py
+++ b/sqlite3_to_mysql/transporter.py
@@ -358,7 +358,10 @@ class SQLite3toMySQL:
             column = dict(row)
             mysql_safe_name = safe_identifier_length(column["name"])
             column_type = self._translate_type_from_sqlite_to_mysql(column["type"])
-            # read more on hidden columns here https://www.sqlite.org/pragma.html#pragma_table_xinfo
+
+            # The hidden" value is 0 for visible columns, 1 for "hidden" columns, 2 for computed
+            # virtual columns and 3 for computed stored columns.
+            # Read more on hidden columns here https://www.sqlite.org/pragma.html#pragma_table_xinfo
             hidden_column = "hidden" in column and column["hidden"] > 0
 
             if not hidden_column:


### PR DESCRIPTION
Addresses #55

Essentially, there are 3 gotchas:

1. There is no way of extracting the expression of the generated column, and even if there were the expressions themselves aren't compatible between the databases.
2. The only way to successfully transfer generated data from SQLite to MySQL is to create these generated columns as normal visible columns and then transfer all the data into them. This ensures that the columns aren't skipped and no data is lost.
3. The method described above only works with a SQLite version that supports [`PRAGMA table_xinfo("table_name")`](https://www.sqlite.org/pragma.html#pragma_table_xinfo) which means that it has to be SQLite v3.26.0 or higher.