### PR TITLE
:sparkles: add --ignore-errors flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Options:
                                   is to create new ones with a numerical
                                   suffix, e.g. 'exising_key' ->
                                   'existing_key_1'
+  --ignore-erros                  Ignores any errors. This might lead to
+                                  data loss and need manual fixing.
   -d, --mysql-database TEXT       MySQL database name  [required]
   -u, --mysql-user TEXT           MySQL user  [required]
   -p, --prompt-mysql-password     Prompt for MySQL password

--- a/sqlite3_to_mysql/cli.py
+++ b/sqlite3_to_mysql/cli.py
@@ -39,7 +39,7 @@ from .mysql_utils import MYSQL_INSERT_METHOD, MYSQL_TEXT_COLUMN_TYPES, mysql_sup
     "'exising_key' -> 'existing_key_1'",
 )
 @click.option(
-    "--ignore-error",
+    "--ignore-errors",
     is_flag=True,
     help="Ignores any SQL errors. This might lead to data loss.",
 )
@@ -123,7 +123,7 @@ def cli(
     sqlite_tables: t.Optional[t.Sequence[str]],
     without_foreign_keys: bool,
     ignore_duplicate_keys: bool,
-    ignore_error: bool,
+    ignore_errors: bool,
     mysql_user: str,
     prompt_mysql_password: bool,
     mysql_password: str,
@@ -174,7 +174,7 @@ def cli(
             mysql_charset=mysql_charset.lower() if mysql_charset else "utf8mb4",
             mysql_collation=mysql_collation.lower() if mysql_collation else None,
             ignore_duplicate_keys=ignore_duplicate_keys,
-            ignore_error=ignore_error,
+            ignore_errors=ignore_errors,
             use_fulltext=use_fulltext,
             with_rowid=with_rowid,
             chunk=chunk,

--- a/sqlite3_to_mysql/cli.py
+++ b/sqlite3_to_mysql/cli.py
@@ -38,6 +38,11 @@ from .mysql_utils import MYSQL_INSERT_METHOD, MYSQL_TEXT_COLUMN_TYPES, mysql_sup
     help="Ignore duplicate keys. The default behavior is to create new ones with a numerical suffix, e.g. "
     "'exising_key' -> 'existing_key_1'",
 )
+@click.option(
+    "--ignore-error",
+    is_flag=True,
+    help="Ignores any SQL errors. This might lead to data loss.",
+)
 @click.option("-d", "--mysql-database", default=None, help="MySQL database name", required=True)
 @click.option("-u", "--mysql-user", default=None, help="MySQL user", required=True)
 @click.option(
@@ -118,6 +123,7 @@ def cli(
     sqlite_tables: t.Optional[t.Sequence[str]],
     without_foreign_keys: bool,
     ignore_duplicate_keys: bool,
+    ignore_error: bool,
     mysql_user: str,
     prompt_mysql_password: bool,
     mysql_password: str,
@@ -168,6 +174,7 @@ def cli(
             mysql_charset=mysql_charset.lower() if mysql_charset else "utf8mb4",
             mysql_collation=mysql_collation.lower() if mysql_collation else None,
             ignore_duplicate_keys=ignore_duplicate_keys,
+            ignore_error=ignore_error,
             use_fulltext=use_fulltext,
             with_rowid=with_rowid,
             chunk=chunk,

--- a/sqlite3_to_mysql/sqlite_utils.py
+++ b/sqlite3_to_mysql/sqlite_utils.py
@@ -41,7 +41,8 @@ def unicase_compare(string_1: str, string_2: str) -> int:
 def convert_date(value) -> date:
     """Handle SQLite date conversion."""
     try:
-        return date.fromisoformat(value.decode())
+        decoded_value: str = value.decode().replace(" ", "T")
+        return date.fromisoformat(decoded_value)
     except ValueError as err:
         raise ValueError(f"DATE field contains {err}")  # pylint: disable=W0707
 

--- a/sqlite3_to_mysql/sqlite_utils.py
+++ b/sqlite3_to_mysql/sqlite_utils.py
@@ -41,7 +41,10 @@ def unicase_compare(string_1: str, string_2: str) -> int:
 def convert_date(value) -> date:
     """Handle SQLite date conversion."""
     try:
-        decoded_value: str = value.decode().replace(" ", "T")
+        decoded_value: str = value.decode()
+        if " " in decoded_value:
+            decoded_value = decoded_value.split(" ")[0]
+                    
         return date.fromisoformat(decoded_value)
     except ValueError as err:
         raise ValueError(f"DATE field contains {err}")  # pylint: disable=W0707

--- a/sqlite3_to_mysql/transporter.py
+++ b/sqlite3_to_mysql/transporter.py
@@ -341,6 +341,13 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
             )
             
             not_null: bool = column["notnull"] or column["pk"]
+
+            # set a standard default value for non-nullable columns            
+            if not_null and not column["dflt_value"]:
+                if column_type == "DATE":
+                    column["dflt_value"] = "0000-00-00"
+                elif column_type == "DATETIME":
+                    column["dflt_value"] = "0000-00-00 00:00:00"
                 
             sql += " `{name}` {type} {notnull} {default} {auto_increment}, ".format(
                 name=mysql_safe_name,

--- a/sqlite3_to_mysql/transporter.py
+++ b/sqlite3_to_mysql/transporter.py
@@ -109,6 +109,7 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
             self._mysql_collation = "utf8mb4_general_ci"
 
         self._ignore_duplicate_keys = kwargs.get("ignore_duplicate_keys") or False
+        self._ignore_error = kwargs.get("ignore_error") or False
 
         self._use_fulltext = kwargs.get("use_fulltext") or False
 
@@ -537,7 +538,8 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
                     ", ".join(safe_identifier_length(index_info["name"]) for index_info in index_infos),
                     safe_identifier_length(table_name),
                 )
-                raise
+                if not self._ignore_error:
+                    raise
             else:
                 self._logger.error(
                     """MySQL failed adding index to column "%s" in table %s: %s""",
@@ -545,7 +547,8 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
                     safe_identifier_length(table_name),
                     err,
                 )
-                raise
+                if not self._ignore_error:
+                    raise
 
     def _add_foreign_keys(self, table_name: str) -> None:
         self._sqlite_cur.execute(f'PRAGMA foreign_key_list("{table_name}")')
@@ -593,7 +596,8 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
                     safe_identifier_length(foreign_key["to"]),
                     err,
                 )
-                raise
+                if not self._ignore_error:
+                    raise
 
     def _transfer_table_data(self, sql: str, total_records: int = 0) -> None:
         if self._chunk_size is not None and self._chunk_size > 0:
@@ -704,7 +708,8 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
                             safe_identifier_length(table["name"]),
                             err,
                         )
-                        raise
+                        if not self._ignore_error:
+                            raise
 
                 # add indices
                 self._add_indices(table["name"])

--- a/sqlite3_to_mysql/transporter.py
+++ b/sqlite3_to_mysql/transporter.py
@@ -339,16 +339,9 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
             auto_increment: bool = (
                 column["pk"] > 0 and column_type.startswith(("INT", "BIGINT")) and not compound_primary_key
             )
-            
+
             not_null: bool = column["notnull"] or column["pk"]
 
-            # set a standard default value for non-nullable columns            
-            if not_null and not column["dflt_value"]:
-                if column_type == "DATE":
-                    column["dflt_value"] = "'0000-00-00'"
-                elif column_type == "DATETIME":
-                    column["dflt_value"] = "'0000-00-00 00:00:00'"
-                
             sql += " `{name}` {type} {notnull} {default} {auto_increment}, ".format(
                 name=mysql_safe_name,
                 type=column_type,

--- a/sqlite3_to_mysql/transporter.py
+++ b/sqlite3_to_mysql/transporter.py
@@ -319,7 +319,16 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
         for row in rows:
             column: t.Dict[str, t.Any] = dict(row)
             mysql_safe_name: str = safe_identifier_length(column["name"])
-            column_type: str = self._translate_type_from_sqlite_to_mysql(column["type"])
+            try:
+                column_type: str = self._translate_type_from_sqlite_to_mysql(column["type"])
+            except ValueError:
+                self._logger.error(
+                    "Invalid column type %s in table %s",
+                    column["type"],
+                    safe_identifier_length(table_name),
+                )
+                if not self._ignore_errors:
+                    raise
 
             # The "hidden" value is 0 for visible columns, 1 for "hidden" columns,
             # 2 for computed virtual columns and 3 for computed stored columns.

--- a/sqlite3_to_mysql/transporter.py
+++ b/sqlite3_to_mysql/transporter.py
@@ -340,18 +340,15 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
                 column["pk"] > 0 and column_type.startswith(("INT", "BIGINT")) and not compound_primary_key
             )
             
-            # If the column is not null, we need to check if it has a default value
             not_null: bool = column["notnull"] or column["pk"]
-            if column["dflt_value"] and column_type not in MYSQL_COLUMN_TYPES_WITHOUT_DEFAULT:
-                not_null = True
-
+                
             sql += " `{name}` {type} {notnull} {default} {auto_increment}, ".format(
                 name=mysql_safe_name,
                 type=column_type,
                 notnull="NOT NULL" if not_null else "NULL",
                 auto_increment="AUTO_INCREMENT" if auto_increment else "",
-                default="DEFAULT " + column["dflt_value"]
-                if column["dflt_value"] and column_type not in MYSQL_COLUMN_TYPES_WITHOUT_DEFAULT and not auto_increment
+                default="DEFAULT " + column["dflt_value"] 
+                if not_null and column["dflt_value"] and not auto_increment
                 else "",
             )
 

--- a/sqlite3_to_mysql/transporter.py
+++ b/sqlite3_to_mysql/transporter.py
@@ -345,9 +345,9 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
             # set a standard default value for non-nullable columns            
             if not_null and not column["dflt_value"]:
                 if column_type == "DATE":
-                    column["dflt_value"] = "0000-00-00"
+                    column["dflt_value"] = "'0000-00-00'"
                 elif column_type == "DATETIME":
-                    column["dflt_value"] = "0000-00-00 00:00:00"
+                    column["dflt_value"] = "'0000-00-00 00:00:00'"
                 
             sql += " `{name}` {type} {notnull} {default} {auto_increment}, ".format(
                 name=mysql_safe_name,

--- a/sqlite3_to_mysql/transporter.py
+++ b/sqlite3_to_mysql/transporter.py
@@ -252,7 +252,7 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
         full_column_type: str = column_type.upper()
         match: t.Optional[t.Match[str]] = self._valid_column_type(column_type)
         if not match:
-            raise ValueError("Invalid column_type!")
+            raise ValueError("Invalid column_type: " + column_type)
 
         data_type: str = match.group(0).upper()
         if data_type in {"TEXT", "CLOB", "STRING"}:

--- a/sqlite3_to_mysql/transporter.py
+++ b/sqlite3_to_mysql/transporter.py
@@ -339,11 +339,16 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
             auto_increment: bool = (
                 column["pk"] > 0 and column_type.startswith(("INT", "BIGINT")) and not compound_primary_key
             )
+            
+            # If the column is not null, we need to check if it has a default value
+            not_null: bool = column["notnull"] or column["pk"]
+            if column["dflt_value"] and column_type not in MYSQL_COLUMN_TYPES_WITHOUT_DEFAULT:
+                not_null = True
 
             sql += " `{name}` {type} {notnull} {default} {auto_increment}, ".format(
                 name=mysql_safe_name,
                 type=column_type,
-                notnull="NOT NULL" if column["notnull"] or column["pk"] else "NULL",
+                notnull="NOT NULL" if not_null else "NULL",
                 auto_increment="AUTO_INCREMENT" if auto_increment else "",
                 default="DEFAULT " + column["dflt_value"]
                 if column["dflt_value"] and column_type not in MYSQL_COLUMN_TYPES_WITHOUT_DEFAULT and not auto_increment

--- a/sqlite3_to_mysql/transporter.py
+++ b/sqlite3_to_mysql/transporter.py
@@ -109,7 +109,7 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
             self._mysql_collation = "utf8mb4_general_ci"
 
         self._ignore_duplicate_keys = kwargs.get("ignore_duplicate_keys") or False
-        self._ignore_error = kwargs.get("ignore_error") or False
+        self._ignore_errors = kwargs.get("ignore_errors") or False
 
         self._use_fulltext = kwargs.get("use_fulltext") or False
 
@@ -374,7 +374,8 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
                 safe_identifier_length(table_name),
                 err,
             )
-            raise
+            if not self._ignore_errors:
+                raise
 
     def _truncate_table(self, table_name: str) -> None:
         self._mysql_cur.execute(
@@ -538,7 +539,7 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
                     ", ".join(safe_identifier_length(index_info["name"]) for index_info in index_infos),
                     safe_identifier_length(table_name),
                 )
-                if not self._ignore_error:
+                if not self._ignore_errors:
                     raise
             else:
                 self._logger.error(
@@ -547,7 +548,7 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
                     safe_identifier_length(table_name),
                     err,
                 )
-                if not self._ignore_error:
+                if not self._ignore_errors:
                     raise
 
     def _add_foreign_keys(self, table_name: str) -> None:
@@ -596,7 +597,7 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
                     safe_identifier_length(foreign_key["to"]),
                     err,
                 )
-                if not self._ignore_error:
+                if not self._ignore_errors:
                     raise
 
     def _transfer_table_data(self, sql: str, total_records: int = 0) -> None:
@@ -708,7 +709,7 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
                             safe_identifier_length(table["name"]),
                             err,
                         )
-                        if not self._ignore_error:
+                        if not self._ignore_errors:
                             raise
 
                 # add indices

--- a/sqlite3_to_mysql/types.py
+++ b/sqlite3_to_mysql/types.py
@@ -29,6 +29,7 @@ class SQLite3toMySQLParams(tx.TypedDict):
     mysql_charset: t.Optional[str]
     mysql_collation: t.Optional[str]
     ignore_duplicate_keys: t.Optional[bool]
+    ignore_error: t.Optional[bool]
     use_fulltext: t.Optional[bool]
     with_rowid: t.Optional[bool]
     mysql_insert_method: t.Optional[str]
@@ -60,6 +61,7 @@ class SQLite3toMySQLAttributes:
     _mysql_charset: str
     _mysql_collation: str
     _ignore_duplicate_keys: bool
+    _ignore_error: bool
     _use_fulltext: bool
     _with_rowid: bool
     _sqlite: Connection

--- a/sqlite3_to_mysql/types.py
+++ b/sqlite3_to_mysql/types.py
@@ -29,7 +29,7 @@ class SQLite3toMySQLParams(tx.TypedDict):
     mysql_charset: t.Optional[str]
     mysql_collation: t.Optional[str]
     ignore_duplicate_keys: t.Optional[bool]
-    ignore_error: t.Optional[bool]
+    ignore_errors: t.Optional[bool]
     use_fulltext: t.Optional[bool]
     with_rowid: t.Optional[bool]
     mysql_insert_method: t.Optional[str]
@@ -61,7 +61,7 @@ class SQLite3toMySQLAttributes:
     _mysql_charset: str
     _mysql_collation: str
     _ignore_duplicate_keys: bool
-    _ignore_error: bool
+    _ignore_errors: bool
     _use_fulltext: bool
     _with_rowid: bool
     _sqlite: Connection


### PR DESCRIPTION
Along with the --ignore-errors flag I also implemented a couple of other minor fixes. In the end it led to the fact that only 4 errors (due to bad design in the original sqlite3 database) needed to get fixed manually.

In the end I'm not 100% sure that the current code (after several revisions) is the best it could be. So I'd be happy about a critical review. In case the changes are too much, I could split this PR.