### PR TITLE
Convert BOOL and BOOLEAN to TINYINT(1)

### DIFF
--- a/src/sqlite3_to_mysql/transporter.py
+++ b/src/sqlite3_to_mysql/transporter.py
@@ -295,7 +295,7 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
                 if "UNSIGNED" in self._mysql_integer_type:
                     return f"{match.group(0).upper()}{length} UNSIGNED"
                 return f"{match.group(0).upper()}{length}{' UNSIGNED' if unsigned else ''}"
-        if data_type in {"BOOLEAN", "BOOL"}:
+        if data_type in {"BOOL", "BOOLEAN"}:
             return "TINYINT(1)"
         if data_type.startswith(("REAL", "DOUBLE", "FLOAT", "DECIMAL", "DEC", "FIXED")):
             return full_column_type

--- a/src/sqlite3_to_mysql/transporter.py
+++ b/src/sqlite3_to_mysql/transporter.py
@@ -295,7 +295,7 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
                 if "UNSIGNED" in self._mysql_integer_type:
                     return f"{match.group(0).upper()}{length} UNSIGNED"
                 return f"{match.group(0).upper()}{length}{' UNSIGNED' if unsigned else ''}"
-        if data_type == "BOOLEAN":
+        if data_type in {"BOOLEAN", "BOOL"}:
             return "TINYINT(1)"
         if data_type.startswith(("REAL", "DOUBLE", "FLOAT", "DECIMAL", "DEC", "FIXED")):
             return full_column_type

--- a/tests/unit/sqlite3_to_mysql_test.py
+++ b/tests/unit/sqlite3_to_mysql_test.py
@@ -72,7 +72,7 @@ class TestSQLite3toMySQL:
             mysql_text_type=mysql_text_type,
         )
 
-        for column in sqlite_column_types + ("INT64",):
+        for column in sqlite_column_types + ("INT64", "BOOL",):
             if column in {"Insert", "insert", "dialect"}:
                 continue
             elif column == "VARCHAR":
@@ -83,7 +83,7 @@ class TestSQLite3toMySQL:
                 assert proc._translate_type_from_sqlite_to_mysql(column) == "BIGINT(19)"
             elif column in {"TINYTEXT", "TEXT", "MEDIUMTEXT", "LONGTEXT"}:
                 assert proc._translate_type_from_sqlite_to_mysql(column) == proc._mysql_text_type
-            elif column == "BOOLEAN":
+            elif column in {"BOOL", "BOOLEAN"}:
                 assert proc._translate_type_from_sqlite_to_mysql(column) == "TINYINT(1)"
             else:
                 assert proc._translate_type_from_sqlite_to_mysql(column) == column

--- a/tests/unit/sqlite3_to_mysql_test.py
+++ b/tests/unit/sqlite3_to_mysql_test.py
@@ -199,6 +199,7 @@ class TestSQLite3toMySQL:
             ("FIXED UNSIGNED", "FIXED UNSIGNED"),
             ("FIXED(10,5)", "FIXED(10,5)"),
             ("FIXED(10,5) UNSIGNED", "FIXED(10,5) UNSIGNED"),
+            ("BOOL", "TINYINT(1)"),
             ("BOOLEAN", "TINYINT(1)"),
             ("INT64", "BIGINT(19)"),
         ],


### PR DESCRIPTION
No merge conflicts anymore and put the two datatypes in a set ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced data type translation in database migration to support both "BOOL" and "BOOLEAN" types, ensuring accurate conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->