### PR TITLE
:sparkles: use dateutil.parse to parse SQLite dates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "Click>=8.1.3",
     "mysql-connector-python>=8.2.0",
     "pytimeparse2",
+    "python-dateutil>=2.9.0.post0",
     "simplejson>=3.19.1",
     "tqdm>=4.65.0",
     "tabulate",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "mysql-connector-python>=8.2.0",
     "pytimeparse2",
     "python-dateutil>=2.9.0.post0",
+    "types_python_dateutil",
     "simplejson>=3.19.1",
     "tqdm>=4.65.0",
     "tabulate",

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,6 +10,7 @@ pytest-mock
 pytest-timeout
 pytimeparse2
 python-dateutil>=2.9.0.post0
+types_python_dateutil
 simplejson>=3.19.1
 types-simplejson
 sqlalchemy>=2.0.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,6 +9,7 @@ pytest-cov
 pytest-mock
 pytest-timeout
 pytimeparse2
+python-dateutil>=2.9.0.post0
 simplejson>=3.19.1
 types-simplejson
 sqlalchemy>=2.0.0

--- a/src/sqlite3_to_mysql/sqlite_utils.py
+++ b/src/sqlite3_to_mysql/sqlite_utils.py
@@ -1,6 +1,7 @@
 """SQLite adapters and converters for unsupported data types."""
 
 from datetime import date, timedelta
+from dateutil.parser import parse as dateutil_parse
 from decimal import Decimal
 
 from packaging import version
@@ -41,7 +42,7 @@ def unicase_compare(string_1: str, string_2: str) -> int:
 def convert_date(value) -> date:
     """Handle SQLite date conversion."""
     try:
-        return date.fromisoformat(value.decode())
+        return dateutil_parse(value.decode()).date()
     except ValueError as err:
         raise ValueError(f"DATE field contains {err}")  # pylint: disable=W0707
 

--- a/src/sqlite3_to_mysql/sqlite_utils.py
+++ b/src/sqlite3_to_mysql/sqlite_utils.py
@@ -1,9 +1,10 @@
 """SQLite adapters and converters for unsupported data types."""
 
+import typing as t
 from datetime import date, timedelta
-from dateutil.parser import parse as dateutil_parse
 from decimal import Decimal
 
+from dateutil.parser import parse as dateutil_parse
 from packaging import version
 from packaging.version import Version
 from pytimeparse2 import parse
@@ -39,7 +40,7 @@ def unicase_compare(string_1: str, string_2: str) -> int:
     return 1 if _string_1 > _string_2 else -1 if _string_1 < _string_2 else 0
 
 
-def convert_date(value) -> date:
+def convert_date(value: t.AnyStr) -> date:
     """Handle SQLite date conversion."""
     try:
         return dateutil_parse(value.decode()).date()

--- a/src/sqlite3_to_mysql/sqlite_utils.py
+++ b/src/sqlite3_to_mysql/sqlite_utils.py
@@ -4,6 +4,7 @@ import typing as t
 from datetime import date, timedelta
 from decimal import Decimal
 
+from dateutil.parser import ParserError
 from dateutil.parser import parse as dateutil_parse
 from packaging import version
 from packaging.version import Version
@@ -44,7 +45,7 @@ def convert_date(value: t.Union[str, bytes]) -> date:
     """Handle SQLite date conversion."""
     try:
         return dateutil_parse(value.decode() if isinstance(value, bytes) else value).date()
-    except ValueError as err:
+    except ParserError as err:
         raise ValueError(f"DATE field contains {err}")  # pylint: disable=W0707
 
 

--- a/src/sqlite3_to_mysql/sqlite_utils.py
+++ b/src/sqlite3_to_mysql/sqlite_utils.py
@@ -40,10 +40,10 @@ def unicase_compare(string_1: str, string_2: str) -> int:
     return 1 if _string_1 > _string_2 else -1 if _string_1 < _string_2 else 0
 
 
-def convert_date(value: t.AnyStr) -> date:
+def convert_date(value: t.Union[str, bytes]) -> date:
     """Handle SQLite date conversion."""
     try:
-        return dateutil_parse(value.decode()).date()
+        return dateutil_parse(value.decode() if isinstance(value, bytes) else value).date()
     except ValueError as err:
         raise ValueError(f"DATE field contains {err}")  # pylint: disable=W0707
 


### PR DESCRIPTION
# Pull Request Template

## Description

Use [dateutil](https://pypi.org/project/python-dateutil/) to parse SQLite dates instead of `datetime.date.fromisoformat`

Fixes #120

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Test suite passes

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules