### PR TITLE
added a --mysql-socket option to connect to MySQL using a Unix socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Options:
   --mysql-password TEXT           MySQL password
   -h, --mysql-host TEXT           MySQL host. Defaults to localhost.
   -P, --mysql-port INTEGER        MySQL port. Defaults to 3306.
+  --mysql-socket TEXT             Path to MySQL unix socket file.
   -S, --skip-ssl                  Disable MySQL connection encryption.
   -i, --mysql-insert-method [DEFAULT|IGNORE|UPDATE]
                                   MySQL insert method. DEFAULT will throw

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -29,6 +29,7 @@ Connection Options
 - ``-h, --mysql-host TEXT``: MySQL host. Defaults to localhost.
 - ``-P, --mysql-port INTEGER``: MySQL port. Defaults to 3306.
 - ``-S, --skip-ssl``: Disable MySQL connection encryption.
+- ``--mysql-socket TEXT``: Path to MySQL unix socket file.
 
 Transfer Options
 """"""""""""""""

--- a/src/sqlite3_to_mysql/cli.py
+++ b/src/sqlite3_to_mysql/cli.py
@@ -62,6 +62,7 @@ _copyright_header: str = f"sqlite3mysql version {package_version} Copyright (c) 
 @click.option("--mysql-password", default=None, help="MySQL password")
 @click.option("-h", "--mysql-host", default="localhost", help="MySQL host. Defaults to localhost.")
 @click.option("-P", "--mysql-port", type=int, default=3306, help="MySQL port. Defaults to 3306.")
+@click.option("--mysql-socket", default=None, help="Path to MySQL unix socket file.")
 @click.option("-S", "--skip-ssl", is_flag=True, help="Disable MySQL connection encryption.")
 @click.option(
     "-i",
@@ -137,6 +138,7 @@ def cli(
     mysql_database: str,
     mysql_host: str,
     mysql_port: int,
+    mysql_socket: str,
     skip_ssl: bool,
     mysql_insert_method: str,
     mysql_truncate_tables: bool,
@@ -183,6 +185,7 @@ def cli(
             mysql_database=mysql_database,
             mysql_host=mysql_host,
             mysql_port=mysql_port,
+            mysql_socket=mysql_socket,
             mysql_ssl_disabled=skip_ssl,
             mysql_insert_method=mysql_insert_method,
             mysql_truncate_tables=mysql_truncate_tables,

--- a/src/sqlite3_to_mysql/transporter.py
+++ b/src/sqlite3_to_mysql/transporter.py
@@ -74,6 +74,8 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
 
         self._mysql_port = kwargs.get("mysql_port", 3306) or 3306
 
+        self._mysql_socket = str(kwargs.get("mysql_socket")) if kwargs.get("mysql_socket") else None
+
         self._sqlite_tables = kwargs.get("sqlite_tables") or tuple()
 
         self._without_foreign_keys = bool(self._sqlite_tables) or bool(kwargs.get("without_foreign_keys", False))
@@ -143,6 +145,7 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
                 password=self._mysql_password,
                 host=self._mysql_host,
                 port=self._mysql_port,
+                unix_socket=self._mysql_socket,
                 ssl_disabled=self._mysql_ssl_disabled,
                 use_pure=True,
                 charset=self._mysql_charset,

--- a/src/sqlite3_to_mysql/types.py
+++ b/src/sqlite3_to_mysql/types.py
@@ -20,6 +20,7 @@ class SQLite3toMySQLParams(tx.TypedDict):
     mysql_password: t.Optional[t.Union[str, bool]]
     mysql_host: t.Optional[str]
     mysql_port: t.Optional[int]
+    mysql_socket: t.Optional[str]
     mysql_ssl_disabled: t.Optional[bool]
     chunk: t.Optional[int]
     quiet: t.Optional[bool]
@@ -49,6 +50,7 @@ class SQLite3toMySQLAttributes:
     _mysql_password: t.Optional[str]
     _mysql_host: str
     _mysql_port: int
+    _mysql_socket: str
     _mysql_ssl_disabled: bool
     _chunk_size: t.Optional[int]
     _quiet: bool


### PR DESCRIPTION
## Description

This adds a `--mysql-socket` option to the CLI which passes a `unix_socket` parameter to the MySQL Connector, which lets you connect using a Unix socket instead of a TCP port.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested with my local database with disabled networking (MacPorts default), with and without the option `--mysql-socket /opt/local/var/run/mysql8/mysqld.sock`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
