### PR TITLE
:arrow_up: update Python version support to include 3.13 and drop 3.8 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,12 +36,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - toxenv: "python3.8"
-            db: "mariadb:5.5"
-            legacy_db: 1
-            experimental: false
-            py: "3.8"
-
           - toxenv: "python3.9"
             db: "mariadb:5.5"
             legacy_db: 1
@@ -66,11 +60,11 @@ jobs:
             experimental: false
             py: "3.12"
 
-          - toxenv: "python3.8"
-            db: "mariadb:10.0"
+          - toxenv: "python3.13"
+            db: "mariadb:5.5"
             legacy_db: 1
             experimental: false
-            py: "3.8"
+            py: "3.13"
 
           - toxenv: "python3.9"
             db: "mariadb:10.0"
@@ -96,11 +90,11 @@ jobs:
             experimental: false
             py: "3.12"
 
-          - toxenv: "python3.8"
-            db: "mariadb:10.1"
+          - toxenv: "python3.13"
+            db: "mariadb:10.0"
             legacy_db: 1
             experimental: false
-            py: "3.8"
+            py: "3.13"
 
           - toxenv: "python3.9"
             db: "mariadb:10.1"
@@ -126,16 +120,16 @@ jobs:
             experimental: false
             py: "3.12"
 
-          - toxenv: "python3.8"
+          - toxenv: "python3.13"
+            db: "mariadb:10.1"
+            legacy_db: 1
+            experimental: false
+            py: "3.13"
+
+          - toxenv: "python3.9"
             db: "mariadb:10.2"
             legacy_db: 0
             experimental: false
-            py: "3.8"
-
-          - toxenv: "python3.9"
-            db: "mariadb:10.2"
-            legacy_db: 0
-            experimental: false
             py: "3.9"
 
           - toxenv: "python3.10"
@@ -156,11 +150,11 @@ jobs:
             experimental: false
             py: "3.12"
 
-          - toxenv: "python3.8"
-            db: "mariadb:10.3"
+          - toxenv: "python3.13"
+            db: "mariadb:10.2"
             legacy_db: 0
             experimental: false
-            py: "3.8"
+            py: "3.13"
 
           - toxenv: "python3.9"
             db: "mariadb:10.3"
@@ -186,11 +180,11 @@ jobs:
             experimental: false
             py: "3.12"
 
-          - toxenv: "python3.8"
-            db: "mariadb:10.4"
+          - toxenv: "python3.13"
+            db: "mariadb:10.3"
             legacy_db: 0
             experimental: false
-            py: "3.8"
+            py: "3.13"
 
           - toxenv: "python3.9"
             db: "mariadb:10.4"
@@ -216,11 +210,11 @@ jobs:
             experimental: false
             py: "3.12"
 
-          - toxenv: "python3.8"
-            db: "mariadb:10.5"
+          - toxenv: "python3.13"
+            db: "mariadb:10.4"
             legacy_db: 0
             experimental: false
-            py: "3.8"
+            py: "3.13"
 
           - toxenv: "python3.9"
             db: "mariadb:10.5"
@@ -246,11 +240,11 @@ jobs:
             experimental: false
             py: "3.12"
 
-          - toxenv: "python3.8"
-            db: "mariadb:10.6"
+          - toxenv: "python3.13"
+            db: "mariadb:10.5"
             legacy_db: 0
             experimental: false
-            py: "3.8"
+            py: "3.13"
 
           - toxenv: "python3.9"
             db: "mariadb:10.6"
@@ -276,11 +270,11 @@ jobs:
             experimental: false
             py: "3.12"
 
-          - toxenv: "python3.8"
-            db: "mariadb:10.11"
+          - toxenv: "python3.13"
+            db: "mariadb:10.6"
             legacy_db: 0
             experimental: false
-            py: "3.8"
+            py: "3.13"
 
           - toxenv: "python3.9"
             db: "mariadb:10.11"
@@ -306,11 +300,11 @@ jobs:
             experimental: false
             py: "3.12"
 
-          - toxenv: "python3.8"
-            db: "mariadb:11.4"
+          - toxenv: "python3.13"
+            db: "mariadb:10.11"
             legacy_db: 0
             experimental: false
-            py: "3.8"
+            py: "3.13"
 
           - toxenv: "python3.9"
             db: "mariadb:11.4"
@@ -336,11 +330,11 @@ jobs:
             experimental: false
             py: "3.12"
 
-          - toxenv: "python3.8"
-            db: "mysql:5.5"
-            legacy_db: 1
+          - toxenv: "python3.13"
+            db: "mariadb:11.4"
+            legacy_db: 0
             experimental: false
-            py: "3.8"
+            py: "3.13"
 
           - toxenv: "python3.9"
             db: "mysql:5.5"
@@ -366,11 +360,11 @@ jobs:
             experimental: false
             py: "3.12"
 
-          - toxenv: "python3.8"
-            db: "mysql:5.6"
+          - toxenv: "python3.13"
+            db: "mysql:5.5"
             legacy_db: 1
             experimental: false
-            py: "3.8"
+            py: "3.13"
 
           - toxenv: "python3.9"
             db: "mysql:5.6"
@@ -396,11 +390,11 @@ jobs:
             experimental: false
             py: "3.12"
 
-          - toxenv: "python3.8"
-            db: "mysql:5.7"
-            legacy_db: 0
+          - toxenv: "python3.13"
+            db: "mysql:5.6"
+            legacy_db: 1
             experimental: false
-            py: "3.8"
+            py: "3.13"
 
           - toxenv: "python3.9"
             db: "mysql:5.7"
@@ -426,11 +420,11 @@ jobs:
             experimental: false
             py: "3.12"
 
-          - toxenv: "python3.8"
-            db: "mysql:8.0"
+          - toxenv: "python3.13"
+            db: "mysql:5.7"
             legacy_db: 0
             experimental: false
-            py: "3.8"
+            py: "3.13"
 
           - toxenv: "python3.9"
             db: "mysql:8.0"
@@ -455,12 +449,11 @@ jobs:
             legacy_db: 0
             experimental: false
             py: "3.12"
-
-          - toxenv: "python3.8"
-            db: "mysql:8.4"
+          - toxenv: "python3.13"
+            db: "mysql:8.0"
             legacy_db: 0
-            experimental: true
-            py: "3.8"
+            experimental: false
+            py: "3.13"
 
           - toxenv: "python3.9"
             db: "mysql:8.4"
@@ -485,8 +478,15 @@ jobs:
             legacy_db: 0
             experimental: true
             py: "3.12"
+
+          - toxenv: "python3.13"
+            db: "mysql:8.4"
+            legacy_db: 0
+            experimental: true
+            py: "3.13"
     continue-on-error: ${{ matrix.experimental }}
     services:
+
       mysql:
         image: ${{ matrix.db }}
         ports:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ interactions related to the project.
 
 Ensuring backward compatibility is an imperative requirement.
 
-Currently, the tool supports Python versions 3.8, 3.9, 3.10, 3.11, and 3.12.
+Currently, the tool supports Python versions 3.9, 3.10, 3.11, 3.12, and 3.13.
 
 ## MySQL version support
 
@@ -61,7 +61,7 @@ git commit -m "A brief summary of the commit
 > 
 > A paragraph describing what changed and its impact."
 ```
-    
+
 ## Coding standards
 
 It is essential to prioritize code readability and conciseness. To achieve this, we recommend

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "sqlite3-to-mysql"
 description = "A simple Python tool to transfer data from SQLite 3 to MySQL"
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     { name = "Klemen Tusar", email = "techouse@gmail.com" },
 ]
@@ -29,11 +29,11 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Database",
 ]
@@ -79,7 +79,7 @@ sqlite3mysql = "sqlite3_to_mysql.cli:cli"
 
 [tool.black]
 line-length = 120
-target-version = ["py38", "py39", "py310", "py311", "py312"]
+target-version = ["py39", "py310", "py311", "py312", "py313"]
 include = '\.pyi?$'
 exclude = '''
 (
@@ -122,7 +122,7 @@ markers = [
 
 [tool.mypy]
 mypy_path = "src"
-python_version = "3.8"
+python_version = "3.9"
 exclude = [
     "tests",
     "docs",

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 isolated_build = true
 envlist =
-    python3.8,
     python3.9,
     python3.10,
     python3.11,
     python3.12,
+    python3.13,
     black,
     flake8,
     linters,
@@ -13,11 +13,11 @@ skip_missing_interpreters = true
 
 [gh-actions]
 python =
-    3.8: python3.8
     3.9: python3.9
     3.10: python3.10
     3.11: python3.11
     3.12: python3.12
+    3.12: python3.13
 
 [testenv]
 passenv =

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ python =
     3.10: python3.10
     3.11: python3.11
     3.12: python3.12
-    3.12: python3.13
+    3.13: python3.13
 
 [testenv]
 passenv =


### PR DESCRIPTION
This pull request includes changes to update the supported Python versions and corresponding configurations in various files. The primary change is the removal of support for Python 3.8 and the addition of support for Python 3.13.

Updates to supported Python versions:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L39-L44): Removed configurations for Python 3.8 and added configurations for Python 3.13 across various database versions. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L39-L44) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L69-R67) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L99-R97) [[4]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L129-R127) [[5]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L159-R157) [[6]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L189-R187) [[7]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L219-R217) [[8]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L249-R247) [[9]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L279-R277) [[10]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L309-R307) [[11]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L339-R337) [[12]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L369-R367) [[13]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L399-R397) [[14]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L429-R427) [[15]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L458-R456) [[16]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R481-R489)

Documentation and configuration updates:

* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L16-R16): Updated the list of supported Python versions to include Python 3.13 and remove Python 3.8.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L10-R10): Updated the `requires-python` field, classifiers, target versions for the Black tool, and the `python_version` for MyPy to reflect the removal of Python 3.8 and the addition of Python 3.13. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L10-R10) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L32-R36) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L82-R82) [[4]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L125-R125)
* [`tox.ini`](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449L4-R20): Removed Python 3.8 from the `envlist` and `gh-actions` sections, and added Python 3.13.