### PR TITLE
feat: add MySQL SSL certificate options and validation to CLI and transporter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -554,10 +554,111 @@ jobs:
             'mysql:8.0'|'mysql:8.4')
               mysql -h127.0.0.1 -uroot -e "SET GLOBAL local_infile=on"
               docker cp mysqld:/var/lib/mysql/public_key.pem "${HOME}"
-              docker cp mysqld:/var/lib/mysql/ca.pem "${HOME}"
-              docker cp mysqld:/var/lib/mysql/server-cert.pem "${HOME}"
-              docker cp mysqld:/var/lib/mysql/client-key.pem "${HOME}"
-              docker cp mysqld:/var/lib/mysql/client-cert.pem "${HOME}"
+
+              cert_dir="$(mktemp -d)"
+              trap 'rm -rf "$cert_dir"' EXIT
+
+              cat > "${cert_dir}/ca.cnf" <<'EOF'
+          [ req ]
+          default_bits = 2048
+          prompt = no
+          default_md = sha256
+          distinguished_name = dn
+          x509_extensions = v3_ca
+
+          [ dn ]
+          CN = sqlite3-to-mysql CI CA
+
+          [ v3_ca ]
+          subjectKeyIdentifier = hash
+          authorityKeyIdentifier = keyid:always,issuer
+          basicConstraints = critical, CA:true
+          keyUsage = critical, keyCertSign, cRLSign
+          EOF
+
+              cat > "${cert_dir}/server.cnf" <<'EOF'
+          [ req ]
+          default_bits = 2048
+          prompt = no
+          default_md = sha256
+          distinguished_name = dn
+
+          [ dn ]
+          CN = localhost
+
+          [ v3_server ]
+          subjectKeyIdentifier = hash
+          authorityKeyIdentifier = keyid,issuer
+          basicConstraints = critical, CA:false
+          keyUsage = critical, digitalSignature, keyEncipherment
+          extendedKeyUsage = serverAuth
+          subjectAltName = @alt_names
+
+          [ alt_names ]
+          DNS.1 = localhost
+          IP.1 = 127.0.0.1
+          IP.2 = 0.0.0.0
+          EOF
+
+              cat > "${cert_dir}/client.cnf" <<'EOF'
+          [ req ]
+          default_bits = 2048
+          prompt = no
+          default_md = sha256
+          distinguished_name = dn
+
+          [ dn ]
+          CN = sqlite3-to-mysql CI client
+
+          [ v3_client ]
+          subjectKeyIdentifier = hash
+          authorityKeyIdentifier = keyid,issuer
+          basicConstraints = critical, CA:false
+          keyUsage = critical, digitalSignature, keyEncipherment
+          extendedKeyUsage = clientAuth
+          EOF
+
+              openssl req -new -x509 -days 365 -nodes -newkey rsa:2048 \
+                -keyout "${cert_dir}/ca-key.pem" \
+                -out "${HOME}/ca.pem" \
+                -config "${cert_dir}/ca.cnf"
+              openssl req -new -nodes -newkey rsa:2048 \
+                -keyout "${cert_dir}/server-key.pem" \
+                -out "${cert_dir}/server.csr" \
+                -config "${cert_dir}/server.cnf"
+              openssl x509 -req \
+                -in "${cert_dir}/server.csr" \
+                -CA "${HOME}/ca.pem" \
+                -CAkey "${cert_dir}/ca-key.pem" \
+                -CAserial "${cert_dir}/ca.srl" \
+                -CAcreateserial \
+                -out "${cert_dir}/server-cert.pem" \
+                -days 365 \
+                -sha256 \
+                -extfile "${cert_dir}/server.cnf" \
+                -extensions v3_server
+              openssl req -new -nodes -newkey rsa:2048 \
+                -keyout "${HOME}/client-key.pem" \
+                -out "${cert_dir}/client.csr" \
+                -config "${cert_dir}/client.cnf"
+              openssl x509 -req \
+                -in "${cert_dir}/client.csr" \
+                -CA "${HOME}/ca.pem" \
+                -CAkey "${cert_dir}/ca-key.pem" \
+                -CAserial "${cert_dir}/ca.srl" \
+                -CAcreateserial \
+                -out "${HOME}/client-cert.pem" \
+                -days 365 \
+                -sha256 \
+                -extfile "${cert_dir}/client.cnf" \
+                -extensions v3_client
+
+              chmod 600 "${HOME}/client-key.pem"
+              docker cp "${HOME}/ca.pem" mysqld:/var/lib/mysql/ca.pem
+              docker cp "${cert_dir}/server-cert.pem" mysqld:/var/lib/mysql/server-cert.pem
+              docker cp "${cert_dir}/server-key.pem" mysqld:/var/lib/mysql/server-key.pem
+              docker exec mysqld sh -c 'chown mysql:mysql /var/lib/mysql/ca.pem /var/lib/mysql/server-cert.pem /var/lib/mysql/server-key.pem && chmod 644 /var/lib/mysql/ca.pem /var/lib/mysql/server-cert.pem && chmod 600 /var/lib/mysql/server-key.pem'
+              mysql -h127.0.0.1 -uroot -e "ALTER INSTANCE RELOAD TLS"
               ;;
           esac
           

--- a/README.md
+++ b/README.md
@@ -60,7 +60,13 @@ Options:
   -h, --mysql-host TEXT           MySQL host. Defaults to localhost.
   -P, --mysql-port INTEGER        MySQL port. Defaults to 3306.
   -k, --mysql-socket PATH         Path to MySQL unix socket file.
-  -S, --skip-ssl                  Disable MySQL connection encryption.
+  --mysql-ssl-ca PATH             Path to SSL CA certificate file.
+  --mysql-ssl-cert PATH           Path to SSL certificate file. Must be
+                                  provided together with --mysql-ssl-key.
+  --mysql-ssl-key PATH            Path to SSL key file. Must be provided
+                                  together with --mysql-ssl-cert.
+  -S, --skip-ssl                  Disable MySQL connection encryption. Cannot
+                                  be used with --mysql-ssl-* options.
   -i, --mysql-insert-method [DEFAULT|IGNORE|UPDATE]
                                   MySQL insert method. DEFAULT will throw
                                   errors when encountering duplicate records;

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Options:
   --mysql-password TEXT           MySQL password
   -h, --mysql-host TEXT           MySQL host. Defaults to localhost.
   -P, --mysql-port INTEGER        MySQL port. Defaults to 3306.
-  -k, --mysql-socket PATH         Path to MySQL unix socket file.
+  -k, --mysql-socket PATH         Path to MySQL unix socket file. Cannot be
+                                  used with --mysql-ssl-* options.
   --mysql-ssl-ca PATH             Path to SSL CA certificate file.
   --mysql-ssl-cert PATH           Path to SSL certificate file. Must be
                                   provided together with --mysql-ssl-key.

--- a/README.md
+++ b/README.md
@@ -61,11 +61,15 @@ Options:
   -P, --mysql-port INTEGER        MySQL port. Defaults to 3306.
   -k, --mysql-socket PATH         Path to MySQL unix socket file. Cannot be
                                   used with --mysql-ssl-* options.
-  --mysql-ssl-ca PATH             Path to SSL CA certificate file.
+  --mysql-ssl-ca PATH             Path to SSL CA certificate file. Cannot be
+                                  used with --mysql-socket or --skip-ssl.
   --mysql-ssl-cert PATH           Path to SSL certificate file. Must be
                                   provided together with --mysql-ssl-key.
+                                  Cannot be used with --mysql-socket or
+                                  --skip-ssl.
   --mysql-ssl-key PATH            Path to SSL key file. Must be provided
-                                  together with --mysql-ssl-cert.
+                                  together with --mysql-ssl-cert. Cannot be
+                                  used with --mysql-socket or --skip-ssl.
   -S, --skip-ssl                  Disable MySQL connection encryption. Cannot
                                   be used with --mysql-ssl-* options.
   -i, --mysql-insert-method [DEFAULT|IGNORE|UPDATE]

--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ Options:
   --help                          Show this message and exit.
 ```
 
+MySQL SSL note: server certificate verification requires `--mysql-ssl-ca`. Internally, `_mysql_ssl_ca`
+sets `connection_args["ssl_verify_cert"]`; `_mysql_ssl_cert` and `_mysql_ssl_key` only provide client
+certificate authentication. When `--mysql-ssl-cert` and `--mysql-ssl-key` are used without
+`--mysql-ssl-ca`, neither `ssl_verify_cert` nor `ssl_verify_identity` is enabled.
+
 #### Docker
 
 If you don't want to install the tool on your system, you can use the Docker image instead.

--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ Options:
   --help                          Show this message and exit.
 ```
 
-MySQL SSL note: server certificate verification requires `--mysql-ssl-ca`. Internally, `_mysql_ssl_ca`
-sets `connection_args["ssl_verify_cert"]`; `_mysql_ssl_cert` and `_mysql_ssl_key` only provide client
-certificate authentication. When `--mysql-ssl-cert` and `--mysql-ssl-key` are used without
-`--mysql-ssl-ca`, neither `ssl_verify_cert` nor `ssl_verify_identity` is enabled.
+MySQL SSL note: when `--mysql-ssl-ca` is provided, MySQL Connector/Python verifies the server
+certificate chain. `--mysql-ssl-cert` and `--mysql-ssl-key` enable client certificate authentication.
+These options do not enable hostname identity verification. If you provide only the client certificate
+and key without `--mysql-ssl-ca`, the server certificate is not verified.
 
 #### Docker
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -34,11 +34,10 @@ Connection Options
 - ``--mysql-ssl-key PATH``: Path to SSL key file. Must be provided together with ``--mysql-ssl-cert``. Cannot be used together with ``--mysql-socket``.
 - ``-S, --skip-ssl``: Disable MySQL connection encryption. Cannot be used together with ``--mysql-ssl-*`` options.
 
-MySQL SSL note: server certificate verification requires ``--mysql-ssl-ca``. Internally,
-``_mysql_ssl_ca`` sets ``connection_args["ssl_verify_cert"]``; ``_mysql_ssl_cert`` and
-``_mysql_ssl_key`` only provide client certificate authentication. When ``--mysql-ssl-cert`` and
-``--mysql-ssl-key`` are used without ``--mysql-ssl-ca``, neither ``ssl_verify_cert`` nor
-``ssl_verify_identity`` is enabled.
+MySQL SSL note: when ``--mysql-ssl-ca`` is provided, MySQL Connector/Python verifies the server
+certificate chain. ``--mysql-ssl-cert`` and ``--mysql-ssl-key`` enable client certificate
+authentication. These options do not enable hostname identity verification. If you provide only the
+client certificate and key without ``--mysql-ssl-ca``, the server certificate is not verified.
 
 Transfer Options
 """"""""""""""""

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -28,7 +28,7 @@ Connection Options
 
 - ``-h, --mysql-host TEXT``: MySQL host. Defaults to localhost.
 - ``-P, --mysql-port INTEGER``: MySQL port. Defaults to 3306.
-- ``--mysql-socket PATH``: Path to MySQL unix socket file. Cannot be used together with ``--mysql-ssl-*`` options.
+- ``-k, --mysql-socket PATH``: Path to MySQL unix socket file. Cannot be used together with ``--mysql-ssl-*`` options.
 - ``--mysql-ssl-ca PATH``: Path to SSL CA certificate file. Cannot be used together with ``--mysql-socket`` or ``--skip-ssl``.
 - ``--mysql-ssl-cert PATH``: Path to SSL certificate file. Must be provided together with ``--mysql-ssl-key``. Cannot be used together with ``--mysql-socket`` or ``--skip-ssl``.
 - ``--mysql-ssl-key PATH``: Path to SSL key file. Must be provided together with ``--mysql-ssl-cert``. Cannot be used together with ``--mysql-socket`` or ``--skip-ssl``.

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -28,7 +28,7 @@ Connection Options
 
 - ``-h, --mysql-host TEXT``: MySQL host. Defaults to localhost.
 - ``-P, --mysql-port INTEGER``: MySQL port. Defaults to 3306.
-- ``--mysql-socket TEXT``: Path to MySQL unix socket file. Cannot be used together with ``--mysql-ssl-*`` options.
+- ``--mysql-socket PATH``: Path to MySQL unix socket file. Cannot be used together with ``--mysql-ssl-*`` options.
 - ``--mysql-ssl-ca PATH``: Path to SSL CA certificate file. Cannot be used together with ``--mysql-socket``.
 - ``--mysql-ssl-cert PATH``: Path to SSL certificate file. Must be provided together with ``--mysql-ssl-key``. Cannot be used together with ``--mysql-socket``.
 - ``--mysql-ssl-key PATH``: Path to SSL key file. Must be provided together with ``--mysql-ssl-cert``. Cannot be used together with ``--mysql-socket``.

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -28,8 +28,11 @@ Connection Options
 
 - ``-h, --mysql-host TEXT``: MySQL host. Defaults to localhost.
 - ``-P, --mysql-port INTEGER``: MySQL port. Defaults to 3306.
-- ``-S, --skip-ssl``: Disable MySQL connection encryption.
 - ``--mysql-socket TEXT``: Path to MySQL unix socket file.
+- ``--mysql-ssl-ca PATH``: Path to SSL CA certificate file.
+- ``--mysql-ssl-cert PATH``: Path to SSL certificate file. Must be provided together with ``--mysql-ssl-key``.
+- ``--mysql-ssl-key PATH``: Path to SSL key file. Must be provided together with ``--mysql-ssl-cert``.
+- ``-S, --skip-ssl``: Disable MySQL connection encryption. Cannot be used together with ``--mysql-ssl-*`` options.
 
 Transfer Options
 """"""""""""""""
@@ -45,7 +48,7 @@ Transfer Options
 - ``--mysql-string-type TEXT``: MySQL default string field type. Defaults to VARCHAR(255).
 - ``--mysql-text-type [LONGTEXT|MEDIUMTEXT|TEXT|TINYTEXT]``: MySQL default text field type. Defaults to TEXT.
 - ``--mysql-charset TEXT``: MySQL database and table character set. Defaults to utf8mb4.
-` ``--mysql-collation TEXT``: MySQL database and table collation
+- ``--mysql-collation TEXT``: MySQL database and table collation.
 - ``-T, --use-fulltext``: Use FULLTEXT indexes on TEXT columns. Will throw an error if your MySQL version does not support InnoDB FULLTEXT indexes!
 - ``-X, --without-foreign-keys``: Do not transfer foreign keys.
 - ``-W, --ignore-duplicate-keys``: Ignore duplicate keys. The default behavior is to create new ones with a numerical suffix, e.g. 'existing_key' -> 'existing_key_1'

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -34,6 +34,12 @@ Connection Options
 - ``--mysql-ssl-key PATH``: Path to SSL key file. Must be provided together with ``--mysql-ssl-cert``. Cannot be used together with ``--mysql-socket``.
 - ``-S, --skip-ssl``: Disable MySQL connection encryption. Cannot be used together with ``--mysql-ssl-*`` options.
 
+MySQL SSL note: server certificate verification requires ``--mysql-ssl-ca``. Internally,
+``_mysql_ssl_ca`` sets ``connection_args["ssl_verify_cert"]``; ``_mysql_ssl_cert`` and
+``_mysql_ssl_key`` only provide client certificate authentication. When ``--mysql-ssl-cert`` and
+``--mysql-ssl-key`` are used without ``--mysql-ssl-ca``, neither ``ssl_verify_cert`` nor
+``ssl_verify_identity`` is enabled.
+
 Transfer Options
 """"""""""""""""
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -28,10 +28,10 @@ Connection Options
 
 - ``-h, --mysql-host TEXT``: MySQL host. Defaults to localhost.
 - ``-P, --mysql-port INTEGER``: MySQL port. Defaults to 3306.
-- ``--mysql-socket TEXT``: Path to MySQL unix socket file.
-- ``--mysql-ssl-ca PATH``: Path to SSL CA certificate file.
-- ``--mysql-ssl-cert PATH``: Path to SSL certificate file. Must be provided together with ``--mysql-ssl-key``.
-- ``--mysql-ssl-key PATH``: Path to SSL key file. Must be provided together with ``--mysql-ssl-cert``.
+- ``--mysql-socket TEXT``: Path to MySQL unix socket file. Cannot be used together with ``--mysql-ssl-*`` options.
+- ``--mysql-ssl-ca PATH``: Path to SSL CA certificate file. Cannot be used together with ``--mysql-socket``.
+- ``--mysql-ssl-cert PATH``: Path to SSL certificate file. Must be provided together with ``--mysql-ssl-key``. Cannot be used together with ``--mysql-socket``.
+- ``--mysql-ssl-key PATH``: Path to SSL key file. Must be provided together with ``--mysql-ssl-cert``. Cannot be used together with ``--mysql-socket``.
 - ``-S, --skip-ssl``: Disable MySQL connection encryption. Cannot be used together with ``--mysql-ssl-*`` options.
 
 Transfer Options

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -29,9 +29,9 @@ Connection Options
 - ``-h, --mysql-host TEXT``: MySQL host. Defaults to localhost.
 - ``-P, --mysql-port INTEGER``: MySQL port. Defaults to 3306.
 - ``--mysql-socket PATH``: Path to MySQL unix socket file. Cannot be used together with ``--mysql-ssl-*`` options.
-- ``--mysql-ssl-ca PATH``: Path to SSL CA certificate file. Cannot be used together with ``--mysql-socket``.
-- ``--mysql-ssl-cert PATH``: Path to SSL certificate file. Must be provided together with ``--mysql-ssl-key``. Cannot be used together with ``--mysql-socket``.
-- ``--mysql-ssl-key PATH``: Path to SSL key file. Must be provided together with ``--mysql-ssl-cert``. Cannot be used together with ``--mysql-socket``.
+- ``--mysql-ssl-ca PATH``: Path to SSL CA certificate file. Cannot be used together with ``--mysql-socket`` or ``--skip-ssl``.
+- ``--mysql-ssl-cert PATH``: Path to SSL certificate file. Must be provided together with ``--mysql-ssl-key``. Cannot be used together with ``--mysql-socket`` or ``--skip-ssl``.
+- ``--mysql-ssl-key PATH``: Path to SSL key file. Must be provided together with ``--mysql-ssl-cert``. Cannot be used together with ``--mysql-socket`` or ``--skip-ssl``.
 - ``-S, --skip-ssl``: Disable MySQL connection encryption. Cannot be used together with ``--mysql-ssl-*`` options.
 
 MySQL SSL note: when ``--mysql-ssl-ca`` is provided, MySQL Connector/Python verifies the server

--- a/src/sqlite3_to_mysql/cli.py
+++ b/src/sqlite3_to_mysql/cli.py
@@ -238,16 +238,16 @@ def cli(
 
         if skip_ssl and any((mysql_ssl_ca, mysql_ssl_cert, mysql_ssl_key)):
             raise click.ClickException(
-                "Error: --skip-ssl and --mysql-ssl-ca/--mysql-ssl-cert/--mysql-ssl-key are mutually exclusive."
+                "--skip-ssl and --mysql-ssl-ca/--mysql-ssl-cert/--mysql-ssl-key are mutually exclusive."
             )
 
         if mysql_socket and any((mysql_ssl_ca, mysql_ssl_cert, mysql_ssl_key)):
             raise click.ClickException(
-                "Error: --mysql-socket and --mysql-ssl-ca/--mysql-ssl-cert/--mysql-ssl-key are mutually exclusive."
+                "--mysql-socket and --mysql-ssl-ca/--mysql-ssl-cert/--mysql-ssl-key are mutually exclusive."
             )
 
         if bool(mysql_ssl_cert) != bool(mysql_ssl_key):
-            raise click.ClickException("Error: --mysql-ssl-cert and --mysql-ssl-key must be provided together.")
+            raise click.ClickException("--mysql-ssl-cert and --mysql-ssl-key must be provided together.")
 
         SQLite3toMySQL(
             sqlite_file=sqlite_file,

--- a/src/sqlite3_to_mysql/cli.py
+++ b/src/sqlite3_to_mysql/cli.py
@@ -84,6 +84,24 @@ _copyright_header: str = f"sqlite3mysql version {package_version} Copyright (c) 
     default=None,
     help="Path to MySQL unix socket file.",
 )
+@click.option(
+    "--mysql-ssl-ca",
+    type=click.Path(exists=True, dir_okay=False, file_okay=True, readable=True),
+    default=None,
+    help="Path to SSL CA certificate file.",
+)
+@click.option(
+    "--mysql-ssl-cert",
+    type=click.Path(exists=True, dir_okay=False, file_okay=True, readable=True),
+    default=None,
+    help="Path to SSL certificate file.",
+)
+@click.option(
+    "--mysql-ssl-key",
+    type=click.Path(exists=True, dir_okay=False, file_okay=True, readable=True),
+    default=None,
+    help="Path to SSL key file.",
+)
 @click.option("-S", "--skip-ssl", is_flag=True, help="Disable MySQL connection encryption.")
 @click.option(
     "-i",
@@ -162,6 +180,9 @@ def cli(
     mysql_host: str,
     mysql_port: int,
     mysql_socket: t.Optional[str],
+    mysql_ssl_ca: t.Optional[str],
+    mysql_ssl_cert: t.Optional[str],
+    mysql_ssl_key: t.Optional[str],
     skip_ssl: bool,
     mysql_insert_method: str,
     mysql_truncate_tables: bool,
@@ -205,6 +226,19 @@ def cli(
                 "Please use only one of them."
             )
 
+        if skip_ssl and any((mysql_ssl_ca, mysql_ssl_cert, mysql_ssl_key)):
+            raise click.ClickException(
+                "Error: --skip-ssl and --mysql-ssl-ca/--mysql-ssl-cert/--mysql-ssl-key are mutually exclusive."
+            )
+
+        if mysql_socket and any((mysql_ssl_ca, mysql_ssl_cert, mysql_ssl_key)):
+            raise click.ClickException(
+                "Error: --mysql-socket and --mysql-ssl-ca/--mysql-ssl-cert/--mysql-ssl-key are mutually exclusive."
+            )
+
+        if bool(mysql_ssl_cert) != bool(mysql_ssl_key):
+            raise click.ClickException("Error: --mysql-ssl-cert and --mysql-ssl-key must be provided together.")
+
         SQLite3toMySQL(
             sqlite_file=sqlite_file,
             sqlite_tables=sqlite_tables or tuple(),
@@ -217,6 +251,9 @@ def cli(
             mysql_host=mysql_host,
             mysql_port=None if mysql_socket else mysql_port,
             mysql_socket=mysql_socket,
+            mysql_ssl_ca=mysql_ssl_ca,
+            mysql_ssl_cert=mysql_ssl_cert,
+            mysql_ssl_key=mysql_ssl_key,
             mysql_ssl_disabled=skip_ssl,
             mysql_insert_method=mysql_insert_method,
             mysql_truncate_tables=mysql_truncate_tables,

--- a/src/sqlite3_to_mysql/cli.py
+++ b/src/sqlite3_to_mysql/cli.py
@@ -82,27 +82,37 @@ _copyright_header: str = f"sqlite3mysql version {package_version} Copyright (c) 
     "--mysql-socket",
     type=click.Path(exists=True),
     default=None,
-    help="Path to MySQL unix socket file.",
+    help="Path to MySQL unix socket file. Cannot be used with --mysql-ssl-* options.",
 )
 @click.option(
     "--mysql-ssl-ca",
     type=click.Path(exists=True, dir_okay=False, file_okay=True, readable=True),
+    metavar="PATH",
     default=None,
-    help="Path to SSL CA certificate file.",
+    help="Path to SSL CA certificate file. Cannot be used with --mysql-socket or --skip-ssl.",
 )
 @click.option(
     "--mysql-ssl-cert",
     type=click.Path(exists=True, dir_okay=False, file_okay=True, readable=True),
+    metavar="PATH",
     default=None,
-    help="Path to SSL certificate file.",
+    help="Path to SSL certificate file. Must be provided together with --mysql-ssl-key. "
+    "Cannot be used with --mysql-socket or --skip-ssl.",
 )
 @click.option(
     "--mysql-ssl-key",
     type=click.Path(exists=True, dir_okay=False, file_okay=True, readable=True),
+    metavar="PATH",
     default=None,
-    help="Path to SSL key file.",
+    help="Path to SSL key file. Must be provided together with --mysql-ssl-cert. "
+    "Cannot be used with --mysql-socket or --skip-ssl.",
 )
-@click.option("-S", "--skip-ssl", is_flag=True, help="Disable MySQL connection encryption.")
+@click.option(
+    "-S",
+    "--skip-ssl",
+    is_flag=True,
+    help="Disable MySQL connection encryption. Cannot be used with --mysql-ssl-* options.",
+)
 @click.option(
     "-i",
     "--mysql-insert-method",

--- a/src/sqlite3_to_mysql/cli.py
+++ b/src/sqlite3_to_mysql/cli.py
@@ -80,7 +80,7 @@ _copyright_header: str = f"sqlite3mysql version {package_version} Copyright (c) 
 @click.option(
     "-k",
     "--mysql-socket",
-    type=click.Path(exists=True),
+    type=click.Path(exists=True, dir_okay=False, file_okay=True),
     default=None,
     help="Path to MySQL unix socket file. Cannot be used with --mysql-ssl-* options.",
 )

--- a/src/sqlite3_to_mysql/transporter.py
+++ b/src/sqlite3_to_mysql/transporter.py
@@ -138,7 +138,19 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
         else:
             self._without_foreign_keys = bool(kwargs.get("without_foreign_keys", False))
 
+        self._mysql_ssl_ca = kwargs.get("mysql_ssl_ca") or None
+        self._mysql_ssl_cert = kwargs.get("mysql_ssl_cert") or None
+        self._mysql_ssl_key = kwargs.get("mysql_ssl_key") or None
         self._mysql_ssl_disabled = bool(kwargs.get("mysql_ssl_disabled", False))
+
+        if self._mysql_ssl_disabled and any((self._mysql_ssl_ca, self._mysql_ssl_cert, self._mysql_ssl_key)):
+            raise ValueError("Cannot use SSL certificate options when SSL is disabled")
+
+        if self._mysql_socket and any((self._mysql_ssl_ca, self._mysql_ssl_cert, self._mysql_ssl_key)):
+            raise ValueError("Cannot use SSL certificate options when connecting through a MySQL socket")
+
+        if bool(self._mysql_ssl_cert) != bool(self._mysql_ssl_key):
+            raise ValueError("mysql_ssl_cert and mysql_ssl_key must be provided together")
 
         # Expect an integer chunk size; normalize to None when unset/invalid or <= 0
         _chunk = kwargs.get("chunk")
@@ -213,6 +225,10 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
         else:
             connection_args["host"] = self._mysql_host
             connection_args["port"] = self._mysql_port
+            connection_args["ssl_ca"] = self._mysql_ssl_ca
+            connection_args["ssl_cert"] = self._mysql_ssl_cert
+            connection_args["ssl_key"] = self._mysql_ssl_key
+            connection_args["ssl_verify_cert"] = self._mysql_ssl_ca is not None
             if self._mysql_ssl_disabled:
                 connection_args["ssl_disabled"] = True
 

--- a/src/sqlite3_to_mysql/transporter.py
+++ b/src/sqlite3_to_mysql/transporter.py
@@ -10,6 +10,7 @@ from decimal import Decimal
 from itertools import chain
 from math import ceil
 from os.path import isfile, realpath
+from pathlib import Path
 from sys import stdout
 
 import mysql.connector
@@ -101,12 +102,12 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
         if not path:
             return None
 
-        resolved_path = realpath(str(path))
-        if not isfile(resolved_path):
+        resolved_path = Path(path).expanduser().resolve()
+        if not resolved_path.is_file():
             raise FileNotFoundError(f"{description} does not exist")
         if not os.access(resolved_path, os.R_OK):
             raise PermissionError(f"{description} is not readable")
-        return resolved_path
+        return str(resolved_path)
 
     def __init__(self, **kwargs: Unpack[SQLite3toMySQLParams]):
         """Constructor."""

--- a/src/sqlite3_to_mysql/transporter.py
+++ b/src/sqlite3_to_mysql/transporter.py
@@ -92,6 +92,22 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
 
     MYSQL_CONNECTOR_VERSION: version.Version = version.parse(mysql_connector_version_string)
 
+    @staticmethod
+    def _normalize_mysql_ssl_file(
+        path: t.Optional[t.Union[str, "os.PathLike[t.Any]"]],
+        description: str,
+    ) -> t.Optional[str]:
+        """Validate and normalize a MySQL SSL certificate path."""
+        if not path:
+            return None
+
+        resolved_path = realpath(str(path))
+        if not isfile(resolved_path):
+            raise FileNotFoundError(f"{description} does not exist")
+        if not os.access(resolved_path, os.R_OK):
+            raise PermissionError(f"{description} is not readable")
+        return resolved_path
+
     def __init__(self, **kwargs: Unpack[SQLite3toMySQLParams]):
         """Constructor."""
         if kwargs.get("sqlite_file") is None:
@@ -138,19 +154,23 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
         else:
             self._without_foreign_keys = bool(kwargs.get("without_foreign_keys", False))
 
-        self._mysql_ssl_ca = kwargs.get("mysql_ssl_ca") or None
-        self._mysql_ssl_cert = kwargs.get("mysql_ssl_cert") or None
-        self._mysql_ssl_key = kwargs.get("mysql_ssl_key") or None
+        mysql_ssl_ca = kwargs.get("mysql_ssl_ca") or None
+        mysql_ssl_cert = kwargs.get("mysql_ssl_cert") or None
+        mysql_ssl_key = kwargs.get("mysql_ssl_key") or None
         self._mysql_ssl_disabled = bool(kwargs.get("mysql_ssl_disabled", False))
 
-        if self._mysql_ssl_disabled and any((self._mysql_ssl_ca, self._mysql_ssl_cert, self._mysql_ssl_key)):
+        if self._mysql_ssl_disabled and any((mysql_ssl_ca, mysql_ssl_cert, mysql_ssl_key)):
             raise ValueError("Cannot use SSL certificate options when SSL is disabled")
 
-        if self._mysql_socket and any((self._mysql_ssl_ca, self._mysql_ssl_cert, self._mysql_ssl_key)):
+        if self._mysql_socket and any((mysql_ssl_ca, mysql_ssl_cert, mysql_ssl_key)):
             raise ValueError("Cannot use SSL certificate options when connecting through a MySQL socket")
 
-        if bool(self._mysql_ssl_cert) != bool(self._mysql_ssl_key):
+        if bool(mysql_ssl_cert) != bool(mysql_ssl_key):
             raise ValueError("mysql_ssl_cert and mysql_ssl_key must be provided together")
+
+        self._mysql_ssl_ca = self._normalize_mysql_ssl_file(mysql_ssl_ca, "MySQL SSL CA certificate file")
+        self._mysql_ssl_cert = self._normalize_mysql_ssl_file(mysql_ssl_cert, "MySQL SSL certificate file")
+        self._mysql_ssl_key = self._normalize_mysql_ssl_file(mysql_ssl_key, "MySQL SSL key file")
 
         # Expect an integer chunk size; normalize to None when unset/invalid or <= 0
         _chunk = kwargs.get("chunk")

--- a/src/sqlite3_to_mysql/transporter.py
+++ b/src/sqlite3_to_mysql/transporter.py
@@ -249,7 +249,6 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
             connection_args["ssl_cert"] = self._mysql_ssl_cert
             connection_args["ssl_key"] = self._mysql_ssl_key
             connection_args["ssl_verify_cert"] = self._mysql_ssl_ca is not None
-            connection_args["ssl_verify_identity"] = self._mysql_ssl_ca is not None
             if self._mysql_ssl_disabled:
                 connection_args["ssl_disabled"] = True
 

--- a/src/sqlite3_to_mysql/transporter.py
+++ b/src/sqlite3_to_mysql/transporter.py
@@ -249,6 +249,7 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
             connection_args["ssl_cert"] = self._mysql_ssl_cert
             connection_args["ssl_key"] = self._mysql_ssl_key
             connection_args["ssl_verify_cert"] = self._mysql_ssl_ca is not None
+            connection_args["ssl_verify_identity"] = self._mysql_ssl_ca is not None
             if self._mysql_ssl_disabled:
                 connection_args["ssl_disabled"] = True
 

--- a/src/sqlite3_to_mysql/types.py
+++ b/src/sqlite3_to_mysql/types.py
@@ -64,9 +64,9 @@ class SQLite3toMySQLAttributes:
     _mysql_host: t.Optional[str]
     _mysql_port: t.Optional[int]
     _mysql_socket: t.Optional[t.Union[str, "os.PathLike[t.Any]"]]
-    _mysql_ssl_ca: t.Optional[t.Union[str, "os.PathLike[t.Any]"]]
-    _mysql_ssl_cert: t.Optional[t.Union[str, "os.PathLike[t.Any]"]]
-    _mysql_ssl_key: t.Optional[t.Union[str, "os.PathLike[t.Any]"]]
+    _mysql_ssl_ca: t.Optional[str]
+    _mysql_ssl_cert: t.Optional[str]
+    _mysql_ssl_key: t.Optional[str]
     _mysql_ssl_disabled: bool
     _chunk_size: t.Optional[int]
     _quiet: bool

--- a/src/sqlite3_to_mysql/types.py
+++ b/src/sqlite3_to_mysql/types.py
@@ -29,6 +29,9 @@ class SQLite3toMySQLParams(TypedDict):
     mysql_host: t.Optional[str]
     mysql_port: t.Optional[int]
     mysql_socket: t.Optional[t.Union[str, "os.PathLike[t.Any]"]]
+    mysql_ssl_ca: t.Optional[t.Union[str, "os.PathLike[t.Any]"]]
+    mysql_ssl_cert: t.Optional[t.Union[str, "os.PathLike[t.Any]"]]
+    mysql_ssl_key: t.Optional[t.Union[str, "os.PathLike[t.Any]"]]
     mysql_ssl_disabled: t.Optional[bool]
     chunk: t.Optional[int]
     quiet: t.Optional[bool]
@@ -61,6 +64,9 @@ class SQLite3toMySQLAttributes:
     _mysql_host: t.Optional[str]
     _mysql_port: t.Optional[int]
     _mysql_socket: t.Optional[t.Union[str, "os.PathLike[t.Any]"]]
+    _mysql_ssl_ca: t.Optional[t.Union[str, "os.PathLike[t.Any]"]]
+    _mysql_ssl_cert: t.Optional[t.Union[str, "os.PathLike[t.Any]"]]
+    _mysql_ssl_key: t.Optional[t.Union[str, "os.PathLike[t.Any]"]]
     _mysql_ssl_disabled: bool
     _chunk_size: t.Optional[int]
     _quiet: bool

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -410,7 +410,7 @@ def mysql_ssl_certs(
                         if dest_name == "client-key.pem":
                             dest_path.chmod(0o600)
                         extracted[filename] = str(dest_path)
-        except (NotFound, OSError, RuntimeError, tarfile.TarError) as err:
+        except (APIError, NotFound, OSError, RuntimeError, tarfile.TarError) as err:
             for dest_path in written_paths:
                 dest_path.unlink(missing_ok=True)
             pytest.fail(f"Could not extract MySQL SSL certs from the Docker container: {err}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -276,7 +276,7 @@ def mysql_instance(mysql_credentials: MySQLCredentials, pytestconfig: Config) ->
                 print(f"Attempting to download Docker image {docker_mysql_image}'")
                 try:
                     client.images.pull(docker_mysql_image)
-                except (HTTPError, NotFound) as err:
+                except (APIError, HTTPError, NotFound) as err:
                     pytest.fail(str(err))
 
             container = client.containers.run(
@@ -313,7 +313,7 @@ def mysql_instance(mysql_credentials: MySQLCredentials, pytestconfig: Config) ->
                     collation="utf8mb4_unicode_ci",
                 )
             except mysql.connector.Error as err:
-                if err.errno == errorcode.CR_SERVER_LOST:
+                if err.errno in (errorcode.CR_SERVER_LOST, errorcode.CR_CONN_HOST_ERROR):
                     # sleep for two seconds and retry the connection
                     sleep(2)
                 else:
@@ -358,10 +358,10 @@ def mysql_ssl_certs(
     del mysql_instance
     db_credentials_file = abspath(join(dirname(__file__), "db_credentials.json"))
     if isfile(db_credentials_file):
-        return None
+        pytest.skip("SSL cert extraction requires the Docker-managed MySQL test container")
 
     if not pytestconfig.getoption("use_docker"):
-        return None
+        pytest.skip("SSL cert extraction requires Docker")
 
     client: DockerClient = docker.from_env()
     try:
@@ -410,10 +410,10 @@ def mysql_ssl_certs(
                         if dest_name == "client-key.pem":
                             dest_path.chmod(0o600)
                         extracted[filename] = str(dest_path)
-        except (NotFound, OSError, RuntimeError, tarfile.TarError):
+        except (NotFound, OSError, RuntimeError, tarfile.TarError) as err:
             for dest_path in written_paths:
                 dest_path.unlink(missing_ok=True)
-            return None
+            pytest.fail(f"Could not extract MySQL SSL certs from the Docker container: {err}")
 
         return MySQLSSLCerts(
             ca=extracted["ca.pem"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -323,11 +323,8 @@ def mysql_instance(mysql_credentials: MySQLCredentials, pytestconfig: Config) ->
                 if mysql_connection and mysql_connection.is_connected():
                     mysql_available = True
                     mysql_connection.close()
-        else:
-            if not mysql_available and mysql_connection_retries <= 0:
-                raise ConnectionAbortedError(
-                    "Maximum MySQL connection retries exhausted! Are you sure MySQL is running?"
-                )
+        if not mysql_available and mysql_connection_retries <= 0:
+            raise ConnectionAbortedError("Maximum MySQL connection retries exhausted! Are you sure MySQL is running?")
 
         yield  # type: ignore[misc]
     finally:
@@ -357,6 +354,7 @@ def mysql_ssl_certs(
     pytestconfig: Config,
     tmp_path_factory: pytest.TempPathFactory,
 ) -> t.Optional[MySQLSSLCerts]:
+    # This dependency starts the MySQL container before we extract generated certs.
     del mysql_instance
     db_credentials_file = abspath(join(dirname(__file__), "db_credentials.json"))
     if isfile(db_credentials_file):
@@ -384,32 +382,38 @@ def mysql_ssl_certs(
         }
 
         extracted: t.Dict[str, str] = {}
-        for filename, dest_name in cert_files.items():
-            try:
+        written_paths: t.List[Path] = []
+        try:
+            for filename, dest_name in cert_files.items():
                 data_stream, _stat = container.get_archive(f"/var/lib/mysql/{filename}")
-            except NotFound:
-                return None
 
-            buf = io.BytesIO()
-            for chunk in data_stream:
-                buf.write(chunk)
-            buf.seek(0)
-            with tarfile.open(fileobj=buf) as tar:
-                member = next(
-                    (tar_member for tar_member in tar.getmembers() if Path(tar_member.name).name == filename),
-                    None,
-                )
-                if member is None:
-                    pytest.fail(f"Docker returned an archive for {filename}, but the file was not present")
+                buf = io.BytesIO()
+                for chunk in data_stream:
+                    buf.write(chunk)
+                buf.seek(0)
+                with tarfile.open(fileobj=buf) as tar:
+                    member = next(
+                        (tar_member for tar_member in tar.getmembers() if Path(tar_member.name).name == filename),
+                        None,
+                    )
+                    if member is None:
+                        raise RuntimeError(f"Docker returned an archive for {filename}, but the file was not present")
 
-                fobj = tar.extractfile(member)
-                if fobj is None:
-                    pytest.fail(f"Could not read {filename} from the Docker archive")
+                    fobj = tar.extractfile(member)
+                    if fobj is None:
+                        raise RuntimeError(f"Could not read {filename} from the Docker archive")
 
-                with fobj:
-                    dest_path = ssl_dir / dest_name
-                    dest_path.write_bytes(fobj.read())
-                    extracted[filename] = str(dest_path)
+                    with fobj:
+                        dest_path = ssl_dir / dest_name
+                        dest_path.write_bytes(fobj.read())
+                        written_paths.append(dest_path)
+                        if dest_name == "client-key.pem":
+                            dest_path.chmod(0o600)
+                        extracted[filename] = str(dest_path)
+        except (NotFound, OSError, RuntimeError, tarfile.TarError):
+            for dest_path in written_paths:
+                dest_path.unlink(missing_ok=True)
+            return None
 
         return MySQLSSLCerts(
             ca=extracted["ca.pem"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -285,7 +285,7 @@ def mysql_instance(mysql_credentials: MySQLCredentials, pytestconfig: Config) ->
                 ports={
                     "3306/tcp": (
                         mysql_credentials.host,
-                        f"{mysql_credentials.port}/tcp",
+                        mysql_credentials.port,
                     )
                 },
                 environment={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -423,13 +423,9 @@ def mysql_ssl_certs(
 
     client: DockerClient = docker.from_env()
     try:
-        container: t.Optional[Container] = None
-        for docker_container in client.containers.list():
-            if docker_container.name == "pytest_sqlite3_to_mysql":
-                container = docker_container
-                break
-
-        if container is None:
+        try:
+            container: Container = client.containers.get("pytest_sqlite3_to_mysql")
+        except NotFound:
             pytest.fail("MySQL test container is running, but SSL cert extraction could not find it")
 
         ssl_dir = tmp_path_factory.mktemp("mysql_ssl_certs")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ from _pytest.config.argparsing import Parser
 from _pytest.legacypath import TempdirFactory
 from click.testing import CliRunner
 from docker import DockerClient
-from docker.errors import NotFound
+from docker.errors import APIError, NotFound
 from docker.models.containers import Container
 from faker import Faker
 from mysql.connector import MySQLConnection, errorcode
@@ -334,7 +334,10 @@ def mysql_instance(mysql_credentials: MySQLCredentials, pytestconfig: Config) ->
         if use_docker:
             try:
                 if container is not None:
-                    container.kill()
+                    try:
+                        container.kill()
+                    except (APIError, NotFound):
+                        pass
             finally:
                 if client is not None:
                     client.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
+import io
 import json
 import socket
+import tarfile
 import typing as t
 from codecs import open
 from contextlib import contextmanager
@@ -103,21 +105,28 @@ def pytest_addoption(parser: "Parser") -> None:
 def cleanup_hanged_docker_containers() -> None:
     try:
         client: DockerClient = docker.from_env()
-        for container in client.containers.list():
-            if container.name == "pytest_sqlite3_to_mysql":
-                container.kill()
-                break
+        try:
+            for container in client.containers.list():
+                if container.name == "pytest_sqlite3_to_mysql":
+                    container.kill()
+                    break
+        finally:
+            client.close()
     except Exception:
         pass
 
 
-def pytest_keyboard_interrupt() -> None:
+def pytest_keyboard_interrupt(excinfo: t.Any) -> None:
+    del excinfo
     try:
         client: DockerClient = docker.from_env()
-        for container in client.containers.list():
-            if container.name == "pytest_sqlite3_to_mysql":
-                container.kill()
-                break
+        try:
+            for container in client.containers.list():
+                if container.name == "pytest_sqlite3_to_mysql":
+                    container.kill()
+                    break
+        finally:
+            client.close()
     except Exception:
         pass
 
@@ -239,6 +248,7 @@ def mysql_credentials(pytestconfig: Config) -> MySQLCredentials:
 
 @pytest.fixture(scope="session")
 def mysql_instance(mysql_credentials: MySQLCredentials, pytestconfig: Config) -> t.Iterator[MySQLConnection]:
+    client: t.Optional[DockerClient] = None
     container: t.Optional[Container] = None
     mysql_connection: t.Optional[t.Union[PooledMySQLConnection, MySQLConnection, CMySQLConnection]] = None
     mysql_available: bool = False
@@ -250,76 +260,161 @@ def mysql_instance(mysql_credentials: MySQLCredentials, pytestconfig: Config) ->
     else:
         use_docker = pytestconfig.getoption("use_docker")
 
-    if use_docker:
-        """Connecting to a MySQL server within a Docker container is quite tricky :P
-        Read more on the issue here https://hub.docker.com/_/mysql#no-connections-until-mysql-init-completes
-        """
-        try:
-            client = docker.from_env()
-        except Exception as err:
-            pytest.fail(str(err))
-
-        docker_mysql_image = pytestconfig.getoption("docker_mysql_image") or "mysql:latest"
-
-        if not any(docker_mysql_image in image.tags for image in client.images.list()):
-            print(f"Attempting to download Docker image {docker_mysql_image}'")
+    try:
+        if use_docker:
+            """Connecting to a MySQL server within a Docker container is quite tricky :P
+            Read more on the issue here https://hub.docker.com/_/mysql#no-connections-until-mysql-init-completes
+            """
             try:
-                client.images.pull(docker_mysql_image)
-            except (HTTPError, NotFound) as err:
+                client = docker.from_env()
+            except Exception as err:
                 pytest.fail(str(err))
 
-        container = client.containers.run(
-            image=docker_mysql_image,
-            name="pytest_sqlite3_to_mysql",
-            ports={
-                "3306/tcp": (
-                    mysql_credentials.host,
-                    f"{mysql_credentials.port}/tcp",
-                )
-            },
-            environment={
-                "MYSQL_RANDOM_ROOT_PASSWORD": "yes",
-                "MYSQL_USER": mysql_credentials.user,
-                "MYSQL_PASSWORD": mysql_credentials.password,
-                "MYSQL_DATABASE": mysql_credentials.database,
-            },
-            command=[
-                "--character-set-server=utf8mb4",
-                "--collation-server=utf8mb4_unicode_ci",
-            ],
-            detach=True,
-            auto_remove=True,
-        )
+            docker_mysql_image = pytestconfig.getoption("docker_mysql_image") or "mysql:latest"
 
-    while not mysql_available and mysql_connection_retries > 0:
-        try:
-            mysql_connection = mysql.connector.connect(
-                user=mysql_credentials.user,
-                password=mysql_credentials.password,
-                host=mysql_credentials.host,
-                port=mysql_credentials.port,
-                charset="utf8mb4",
-                collation="utf8mb4_unicode_ci",
+            if not any(docker_mysql_image in image.tags for image in client.images.list()):
+                print(f"Attempting to download Docker image {docker_mysql_image}'")
+                try:
+                    client.images.pull(docker_mysql_image)
+                except (HTTPError, NotFound) as err:
+                    pytest.fail(str(err))
+
+            container = client.containers.run(
+                image=docker_mysql_image,
+                name="pytest_sqlite3_to_mysql",
+                ports={
+                    "3306/tcp": (
+                        mysql_credentials.host,
+                        f"{mysql_credentials.port}/tcp",
+                    )
+                },
+                environment={
+                    "MYSQL_RANDOM_ROOT_PASSWORD": "yes",
+                    "MYSQL_USER": mysql_credentials.user,
+                    "MYSQL_PASSWORD": mysql_credentials.password,
+                    "MYSQL_DATABASE": mysql_credentials.database,
+                },
+                command=[
+                    "--character-set-server=utf8mb4",
+                    "--collation-server=utf8mb4_unicode_ci",
+                ],
+                detach=True,
+                auto_remove=True,
             )
-        except mysql.connector.Error as err:
-            if err.errno == errorcode.CR_SERVER_LOST:
-                # sleep for two seconds and retry the connection
-                sleep(2)
-            else:
-                raise
-        finally:
-            mysql_connection_retries -= 1
-            if mysql_connection and mysql_connection.is_connected():
-                mysql_available = True
-                mysql_connection.close()
-    else:
-        if not mysql_available and mysql_connection_retries <= 0:
-            raise ConnectionAbortedError("Maximum MySQL connection retries exhausted! Are you sure MySQL is running?")
 
-    yield  # type: ignore[misc]
+        while not mysql_available and mysql_connection_retries > 0:
+            try:
+                mysql_connection = mysql.connector.connect(
+                    user=mysql_credentials.user,
+                    password=mysql_credentials.password,
+                    host=mysql_credentials.host,
+                    port=mysql_credentials.port,
+                    charset="utf8mb4",
+                    collation="utf8mb4_unicode_ci",
+                )
+            except mysql.connector.Error as err:
+                if err.errno == errorcode.CR_SERVER_LOST:
+                    # sleep for two seconds and retry the connection
+                    sleep(2)
+                else:
+                    raise
+            finally:
+                mysql_connection_retries -= 1
+                if mysql_connection and mysql_connection.is_connected():
+                    mysql_available = True
+                    mysql_connection.close()
+        else:
+            if not mysql_available and mysql_connection_retries <= 0:
+                raise ConnectionAbortedError(
+                    "Maximum MySQL connection retries exhausted! Are you sure MySQL is running?"
+                )
 
-    if use_docker and container is not None:
-        container.kill()
+        yield  # type: ignore[misc]
+    finally:
+        if use_docker:
+            try:
+                if container is not None:
+                    container.kill()
+            finally:
+                if client is not None:
+                    client.close()
+
+
+class MySQLSSLCerts(t.NamedTuple):
+    """Paths to MySQL SSL certificate files extracted from the Docker container."""
+
+    ca: str
+    client_cert: str
+    client_key: str
+
+
+@pytest.fixture(scope="session")
+def mysql_ssl_certs(
+    mysql_instance: MySQLConnection,
+    pytestconfig: Config,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> t.Optional[MySQLSSLCerts]:
+    del mysql_instance
+    db_credentials_file = abspath(join(dirname(__file__), "db_credentials.json"))
+    if isfile(db_credentials_file):
+        return None
+
+    if not pytestconfig.getoption("use_docker"):
+        return None
+
+    client: DockerClient = docker.from_env()
+    try:
+        container: t.Optional[Container] = None
+        for docker_container in client.containers.list():
+            if docker_container.name == "pytest_sqlite3_to_mysql":
+                container = docker_container
+                break
+
+        if container is None:
+            pytest.fail("MySQL test container is running, but SSL cert extraction could not find it")
+
+        ssl_dir = tmp_path_factory.mktemp("mysql_ssl_certs")
+        cert_files = {
+            "ca.pem": "ca.pem",
+            "client-cert.pem": "client-cert.pem",
+            "client-key.pem": "client-key.pem",
+        }
+
+        extracted: t.Dict[str, str] = {}
+        for filename, dest_name in cert_files.items():
+            try:
+                data_stream, _stat = container.get_archive(f"/var/lib/mysql/{filename}")
+            except NotFound:
+                return None
+
+            buf = io.BytesIO()
+            for chunk in data_stream:
+                buf.write(chunk)
+            buf.seek(0)
+            with tarfile.open(fileobj=buf) as tar:
+                member = next(
+                    (tar_member for tar_member in tar.getmembers() if Path(tar_member.name).name == filename),
+                    None,
+                )
+                if member is None:
+                    pytest.fail(f"Docker returned an archive for {filename}, but the file was not present")
+
+                fobj = tar.extractfile(member)
+                if fobj is None:
+                    pytest.fail(f"Could not read {filename} from the Docker archive")
+
+                with fobj:
+                    dest_path = ssl_dir / dest_name
+                    dest_path.write_bytes(fobj.read())
+                    extracted[filename] = str(dest_path)
+
+        return MySQLSSLCerts(
+            ca=extracted["ca.pem"],
+            client_cert=extracted["client-cert.pem"],
+            client_key=extracted["client-key.pem"],
+        )
+    finally:
+        client.close()
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -274,7 +274,7 @@ def mysql_instance(mysql_credentials: MySQLCredentials, pytestconfig: Config) ->
             docker_mysql_image = pytestconfig.getoption("docker_mysql_image") or "mysql:latest"
 
             if not any(docker_mysql_image in image.tags for image in client.images.list()):
-                print(f"Attempting to download Docker image {docker_mysql_image}'")
+                print(f"Attempting to download Docker image {docker_mysql_image}")
                 try:
                     client.images.pull(docker_mysql_image)
                 except (APIError, HTTPError, NotFound) as err:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import io
 import json
+import os
 import socket
 import tarfile
 import typing as t
@@ -341,11 +342,61 @@ def mysql_instance(mysql_credentials: MySQLCredentials, pytestconfig: Config) ->
 
 
 class MySQLSSLCerts(t.NamedTuple):
-    """Paths to MySQL SSL certificate files extracted from the Docker container."""
+    """Paths to MySQL SSL certificate files for functional tests."""
 
     ca: str
     client_cert: str
     client_key: str
+
+
+def _mysql_ssl_certs_from_paths(
+    ca: t.Union[str, Path],
+    client_cert: t.Union[str, Path],
+    client_key: t.Union[str, Path],
+    source: str,
+) -> MySQLSSLCerts:
+    certs = MySQLSSLCerts(
+        ca=str(Path(ca).expanduser().resolve()),
+        client_cert=str(Path(client_cert).expanduser().resolve()),
+        client_key=str(Path(client_key).expanduser().resolve()),
+    )
+    cert_paths = (Path(certs.ca), Path(certs.client_cert), Path(certs.client_key))
+    missing_paths = [str(cert_path) for cert_path in cert_paths if not cert_path.is_file()]
+    if missing_paths:
+        pytest.fail(f"{source} MySQL SSL cert file does not exist: {', '.join(missing_paths)}")
+
+    unreadable_paths = [str(cert_path) for cert_path in cert_paths if not os.access(cert_path, os.R_OK)]
+    if unreadable_paths:
+        pytest.fail(f"{source} MySQL SSL cert file is not readable: {', '.join(unreadable_paths)}")
+
+    return certs
+
+
+def _mysql_ssl_certs_from_environment() -> t.Optional[MySQLSSLCerts]:
+    ca = os.environ.get("MYSQL_SSL_CA")
+    client_cert = os.environ.get("MYSQL_SSL_CERT")
+    client_key = os.environ.get("MYSQL_SSL_KEY")
+    if not any((ca, client_cert, client_key)):
+        return None
+
+    if not all((ca, client_cert, client_key)):
+        pytest.fail("MYSQL_SSL_CA, MYSQL_SSL_CERT, and MYSQL_SSL_KEY must be set together")
+
+    assert ca is not None
+    assert client_cert is not None
+    assert client_key is not None
+    return _mysql_ssl_certs_from_paths(ca, client_cert, client_key, "Configured")
+
+
+def _mysql_ssl_certs_from_home() -> t.Optional[MySQLSSLCerts]:
+    home = Path.home()
+    ca = home / "ca.pem"
+    client_cert = home / "client-cert.pem"
+    client_key = home / "client-key.pem"
+    if not all(cert_path.is_file() for cert_path in (ca, client_cert, client_key)):
+        return None
+
+    return _mysql_ssl_certs_from_paths(ca, client_cert, client_key, "Home directory")
 
 
 @pytest.fixture(scope="session")
@@ -354,14 +405,21 @@ def mysql_ssl_certs(
     pytestconfig: Config,
     tmp_path_factory: pytest.TempPathFactory,
 ) -> t.Optional[MySQLSSLCerts]:
-    # This dependency starts the MySQL container before we extract generated certs.
+    # This dependency starts MySQL before we collect matching SSL certs.
     del mysql_instance
+    configured_ssl_certs = _mysql_ssl_certs_from_environment() or _mysql_ssl_certs_from_home()
+    if configured_ssl_certs is not None:
+        return configured_ssl_certs
+
     db_credentials_file = abspath(join(dirname(__file__), "db_credentials.json"))
     if isfile(db_credentials_file):
-        pytest.skip("SSL cert extraction requires the Docker-managed MySQL test container")
+        pytest.skip(
+            "SSL cert paths are required when using tests/db_credentials.json; set MYSQL_SSL_CA, MYSQL_SSL_CERT, "
+            "and MYSQL_SSL_KEY or copy ca.pem, client-cert.pem, and client-key.pem to $HOME"
+        )
 
     if not pytestconfig.getoption("use_docker"):
-        pytest.skip("SSL cert extraction requires Docker")
+        pytest.skip("SSL cert extraction requires Docker or configured SSL cert paths")
 
     client: DockerClient = docker.from_env()
     try:

--- a/tests/func/test_cli.py
+++ b/tests/func/test_cli.py
@@ -13,7 +13,7 @@ from sqlalchemy.engine import Engine, Inspector
 from sqlite3_to_mysql import SQLite3toMySQL
 from sqlite3_to_mysql import __version__ as package_version
 from sqlite3_to_mysql.cli import cli as sqlite3mysql
-from tests.conftest import MySQLCredentials
+from tests.conftest import MySQLCredentials, MySQLSSLCerts
 
 
 @pytest.mark.cli
@@ -842,3 +842,181 @@ class TestSQLite3toMySQL:
             f"{sqlite3mysql.name} version {package_version} Copyright (c) 2018-{datetime.now().year} Klemen Tusar"
             in result.output
         )
+
+
+@pytest.mark.cli
+@pytest.mark.usefixtures("mysql_instance")
+class TestSQLite3toMySQLSSL:
+    def test_ssl_connection_with_all_options(
+        self,
+        cli_runner: CliRunner,
+        sqlite_database: str,
+        mysql_database: Engine,
+        mysql_credentials: MySQLCredentials,
+        mysql_ssl_certs: t.Optional["MySQLSSLCerts"],
+    ) -> None:
+        del mysql_database
+        if mysql_ssl_certs is None:
+            pytest.skip("SSL certs not available for this environment")
+
+        result: Result = cli_runner.invoke(
+            sqlite3mysql,
+            [
+                "-f",
+                sqlite_database,
+                "-d",
+                mysql_credentials.database,
+                "-u",
+                mysql_credentials.user,
+                "--mysql-password",
+                mysql_credentials.password,
+                "-h",
+                mysql_credentials.host,
+                "-P",
+                str(mysql_credentials.port),
+                "--mysql-ssl-ca",
+                str(mysql_ssl_certs.ca),
+                "--mysql-ssl-cert",
+                str(mysql_ssl_certs.client_cert),
+                "--mysql-ssl-key",
+                str(mysql_ssl_certs.client_key),
+            ],
+        )
+
+        assert result.exit_code == 0
+
+    def test_ssl_connection_ca_only(
+        self,
+        cli_runner: CliRunner,
+        sqlite_database: str,
+        mysql_database: Engine,
+        mysql_credentials: MySQLCredentials,
+        mysql_ssl_certs: t.Optional["MySQLSSLCerts"],
+    ) -> None:
+        del mysql_database
+        if mysql_ssl_certs is None:
+            pytest.skip("SSL certs not available for this environment")
+
+        result: Result = cli_runner.invoke(
+            sqlite3mysql,
+            [
+                "-f",
+                sqlite_database,
+                "-d",
+                mysql_credentials.database,
+                "-u",
+                mysql_credentials.user,
+                "--mysql-password",
+                mysql_credentials.password,
+                "-h",
+                mysql_credentials.host,
+                "-P",
+                str(mysql_credentials.port),
+                "--mysql-ssl-ca",
+                str(mysql_ssl_certs.ca),
+            ],
+        )
+
+        assert result.exit_code == 0
+
+    def test_ssl_connection_cert_and_key_without_ca(
+        self,
+        cli_runner: CliRunner,
+        sqlite_database: str,
+        mysql_database: Engine,
+        mysql_credentials: MySQLCredentials,
+        mysql_ssl_certs: t.Optional["MySQLSSLCerts"],
+    ) -> None:
+        del mysql_database
+        if mysql_ssl_certs is None:
+            pytest.skip("SSL certs not available for this environment")
+
+        result: Result = cli_runner.invoke(
+            sqlite3mysql,
+            [
+                "-f",
+                sqlite_database,
+                "-d",
+                mysql_credentials.database,
+                "-u",
+                mysql_credentials.user,
+                "--mysql-password",
+                mysql_credentials.password,
+                "-h",
+                mysql_credentials.host,
+                "-P",
+                str(mysql_credentials.port),
+                "--mysql-ssl-cert",
+                str(mysql_ssl_certs.client_cert),
+                "--mysql-ssl-key",
+                str(mysql_ssl_certs.client_key),
+            ],
+        )
+
+        assert result.exit_code == 0
+
+    def test_ssl_connection_cert_without_key_fails(
+        self,
+        cli_runner: CliRunner,
+        sqlite_database: str,
+        mysql_credentials: MySQLCredentials,
+        mysql_ssl_certs: t.Optional["MySQLSSLCerts"],
+    ) -> None:
+        if mysql_ssl_certs is None:
+            pytest.skip("SSL certs not available for this environment")
+
+        result: Result = cli_runner.invoke(
+            sqlite3mysql,
+            [
+                "-f",
+                sqlite_database,
+                "-d",
+                mysql_credentials.database,
+                "-u",
+                mysql_credentials.user,
+                "--mysql-password",
+                mysql_credentials.password,
+                "-h",
+                mysql_credentials.host,
+                "-P",
+                str(mysql_credentials.port),
+                "--mysql-ssl-cert",
+                str(mysql_ssl_certs.client_cert),
+            ],
+        )
+
+        assert result.exit_code > 0
+        assert "must be provided together" in result.output
+
+    def test_ssl_connection_key_without_cert_fails(
+        self,
+        cli_runner: CliRunner,
+        sqlite_database: str,
+        mysql_credentials: MySQLCredentials,
+        mysql_ssl_certs: t.Optional["MySQLSSLCerts"],
+    ) -> None:
+        if mysql_ssl_certs is None:
+            pytest.skip("SSL certs not available for this environment")
+
+        result: Result = cli_runner.invoke(
+            sqlite3mysql,
+            [
+                "-f",
+                sqlite_database,
+                "-d",
+                mysql_credentials.database,
+                "-u",
+                mysql_credentials.user,
+                "--mysql-password",
+                mysql_credentials.password,
+                "-h",
+                mysql_credentials.host,
+                "-P",
+                str(mysql_credentials.port),
+                "--mysql-ssl-key",
+                str(mysql_ssl_certs.client_key),
+            ],
+        )
+
+        assert result.exit_code > 0
+        assert "must be provided together" in result.output

--- a/tests/unit/mysql_ssl_certs_fixture_test.py
+++ b/tests/unit/mysql_ssl_certs_fixture_test.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import (
+    MySQLSSLCerts,
+    _mysql_ssl_certs_from_environment,
+    _mysql_ssl_certs_from_home,
+)
+
+
+def _write_ssl_cert_files(directory: Path) -> MySQLSSLCerts:
+    ca = directory / "ca.pem"
+    client_cert = directory / "client-cert.pem"
+    client_key = directory / "client-key.pem"
+    for cert_path in (ca, client_cert, client_key):
+        cert_path.write_text("fake")
+
+    return MySQLSSLCerts(
+        ca=str(ca.resolve()),
+        client_cert=str(client_cert.resolve()),
+        client_key=str(client_key.resolve()),
+    )
+
+
+def test_mysql_ssl_certs_from_environment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    certs = _write_ssl_cert_files(tmp_path)
+    monkeypatch.setenv("MYSQL_SSL_CA", certs.ca)
+    monkeypatch.setenv("MYSQL_SSL_CERT", certs.client_cert)
+    monkeypatch.setenv("MYSQL_SSL_KEY", certs.client_key)
+
+    assert _mysql_ssl_certs_from_environment() == certs
+
+
+def test_mysql_ssl_certs_from_environment_requires_all_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("MYSQL_SSL_CA", str(tmp_path / "ca.pem"))
+
+    with pytest.raises(pytest.fail.Exception, match="must be set together"):
+        _mysql_ssl_certs_from_environment()
+
+
+def test_mysql_ssl_certs_from_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    certs = _write_ssl_cert_files(tmp_path)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    assert _mysql_ssl_certs_from_home() == certs

--- a/tests/unit/mysql_ssl_certs_fixture_test.py
+++ b/tests/unit/mysql_ssl_certs_fixture_test.py
@@ -24,6 +24,9 @@ def _write_ssl_cert_files(directory: Path) -> MySQLSSLCerts:
 
 
 def test_mysql_ssl_certs_from_environment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("MYSQL_SSL_CA", raising=False)
+    monkeypatch.delenv("MYSQL_SSL_CERT", raising=False)
+    monkeypatch.delenv("MYSQL_SSL_KEY", raising=False)
     certs = _write_ssl_cert_files(tmp_path)
     monkeypatch.setenv("MYSQL_SSL_CA", certs.ca)
     monkeypatch.setenv("MYSQL_SSL_CERT", certs.client_cert)
@@ -36,6 +39,9 @@ def test_mysql_ssl_certs_from_environment_requires_all_paths(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    monkeypatch.delenv("MYSQL_SSL_CA", raising=False)
+    monkeypatch.delenv("MYSQL_SSL_CERT", raising=False)
+    monkeypatch.delenv("MYSQL_SSL_KEY", raising=False)
     monkeypatch.setenv("MYSQL_SSL_CA", str(tmp_path / "ca.pem"))
 
     with pytest.raises(pytest.fail.Exception, match="must be set together"):
@@ -44,6 +50,6 @@ def test_mysql_ssl_certs_from_environment_requires_all_paths(
 
 def test_mysql_ssl_certs_from_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     certs = _write_ssl_cert_files(tmp_path)
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path), raising=True)
 
     assert _mysql_ssl_certs_from_home() == certs

--- a/tests/unit/sqlite3_to_mysql_test.py
+++ b/tests/unit/sqlite3_to_mysql_test.py
@@ -236,6 +236,34 @@ def test_cli_mysql_socket_with_ssl_options_rejected(
     transporter_ctor.assert_not_called()
 
 
+def test_cli_mysql_socket_directory_rejected(
+    cli_runner: CliRunner,
+    sqlite_database: str,
+    mysql_credentials: MySQLCredentials,
+    tmp_path,
+    mocker: MockerFixture,
+) -> None:
+    transporter_ctor = mocker.patch("sqlite3_to_mysql.cli.SQLite3toMySQL", autospec=True)
+
+    result = cli_runner.invoke(
+        sqlite3mysql,
+        [
+            "-f",
+            sqlite_database,
+            "-d",
+            mysql_credentials.database,
+            "-u",
+            mysql_credentials.user,
+            "--mysql-socket",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code > 0
+    assert "is a directory" in result.output
+    transporter_ctor.assert_not_called()
+
+
 def test_cli_ssl_cert_without_key_rejected(
     cli_runner: CliRunner,
     sqlite_database: str,
@@ -681,6 +709,26 @@ class TestSSLOptions:
         assert instance._mysql_ssl_key is None
         assert connect_kwargs["ssl_ca"] == str(ca_file.resolve())
         assert connect_kwargs["ssl_verify_cert"] is True
+
+    def test_ssl_ca_expands_home_directory(
+        self,
+        sqlite_database: str,
+        tmp_path,
+        monkeypatch: pytest.MonkeyPatch,
+        mocker: MockerFixture,
+    ) -> None:
+        ca_file = tmp_path / "ca.pem"
+        ca_file.write_text("fake")
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        instance, connect_kwargs = self._make_instance(
+            sqlite_database,
+            mocker,
+            mysql_ssl_ca="~/ca.pem",
+        )
+
+        assert instance._mysql_ssl_ca == str(ca_file.resolve())
+        assert connect_kwargs["ssl_ca"] == str(ca_file.resolve())
 
     def test_ssl_cert_and_key_without_ca(
         self,

--- a/tests/unit/sqlite3_to_mysql_test.py
+++ b/tests/unit/sqlite3_to_mysql_test.py
@@ -103,6 +103,199 @@ def test_cli_collation_validation(
     assert "Invalid value for '--collation'" in result.output
 
 
+def test_cli_ssl_options_passed_to_transporter(
+    cli_runner: CliRunner,
+    sqlite_database: str,
+    mysql_credentials: MySQLCredentials,
+    tmp_path,
+    mocker: MockerFixture,
+) -> None:
+    transporter_ctor = mocker.patch("sqlite3_to_mysql.cli.SQLite3toMySQL", autospec=True)
+    transporter_ctor.return_value.transfer.return_value = None
+    ca_file = tmp_path / "ca.pem"
+    cert_file = tmp_path / "client-cert.pem"
+    key_file = tmp_path / "client-key.pem"
+    for cert_path in (ca_file, cert_file, key_file):
+        cert_path.write_text("fake")
+
+    result = cli_runner.invoke(
+        sqlite3mysql,
+        [
+            "-f",
+            sqlite_database,
+            "-d",
+            mysql_credentials.database,
+            "-u",
+            mysql_credentials.user,
+            "--mysql-ssl-ca",
+            str(ca_file),
+            "--mysql-ssl-cert",
+            str(cert_file),
+            "--mysql-ssl-key",
+            str(key_file),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert transporter_ctor.call_args.kwargs["mysql_ssl_ca"] == str(ca_file)
+    assert transporter_ctor.call_args.kwargs["mysql_ssl_cert"] == str(cert_file)
+    assert transporter_ctor.call_args.kwargs["mysql_ssl_key"] == str(key_file)
+    assert transporter_ctor.call_args.kwargs["mysql_ssl_disabled"] is False
+
+
+def test_cli_ssl_options_default_to_none(
+    cli_runner: CliRunner,
+    sqlite_database: str,
+    mysql_credentials: MySQLCredentials,
+    mocker: MockerFixture,
+) -> None:
+    transporter_ctor = mocker.patch("sqlite3_to_mysql.cli.SQLite3toMySQL", autospec=True)
+    transporter_ctor.return_value.transfer.return_value = None
+
+    result = cli_runner.invoke(
+        sqlite3mysql,
+        [
+            "-f",
+            sqlite_database,
+            "-d",
+            mysql_credentials.database,
+            "-u",
+            mysql_credentials.user,
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert transporter_ctor.call_args.kwargs["mysql_ssl_ca"] is None
+    assert transporter_ctor.call_args.kwargs["mysql_ssl_cert"] is None
+    assert transporter_ctor.call_args.kwargs["mysql_ssl_key"] is None
+    assert transporter_ctor.call_args.kwargs["mysql_ssl_disabled"] is False
+
+
+def test_cli_skip_ssl_with_ssl_options_rejected(
+    cli_runner: CliRunner,
+    sqlite_database: str,
+    mysql_credentials: MySQLCredentials,
+    tmp_path,
+    mocker: MockerFixture,
+) -> None:
+    transporter_ctor = mocker.patch("sqlite3_to_mysql.cli.SQLite3toMySQL", autospec=True)
+    ca_file = tmp_path / "ca.pem"
+    ca_file.write_text("fake")
+
+    result = cli_runner.invoke(
+        sqlite3mysql,
+        [
+            "-f",
+            sqlite_database,
+            "-d",
+            mysql_credentials.database,
+            "-u",
+            mysql_credentials.user,
+            "--skip-ssl",
+            "--mysql-ssl-ca",
+            str(ca_file),
+        ],
+    )
+
+    assert result.exit_code > 0
+    assert "mutually exclusive" in result.output
+    transporter_ctor.assert_not_called()
+
+
+def test_cli_mysql_socket_with_ssl_options_rejected(
+    cli_runner: CliRunner,
+    sqlite_database: str,
+    mysql_credentials: MySQLCredentials,
+    tmp_path,
+    mocker: MockerFixture,
+) -> None:
+    transporter_ctor = mocker.patch("sqlite3_to_mysql.cli.SQLite3toMySQL", autospec=True)
+    socket_file = tmp_path / "mysql.sock"
+    ca_file = tmp_path / "ca.pem"
+    socket_file.write_text("")
+    ca_file.write_text("fake")
+
+    result = cli_runner.invoke(
+        sqlite3mysql,
+        [
+            "-f",
+            sqlite_database,
+            "-d",
+            mysql_credentials.database,
+            "-u",
+            mysql_credentials.user,
+            "--mysql-socket",
+            str(socket_file),
+            "--mysql-ssl-ca",
+            str(ca_file),
+        ],
+    )
+
+    assert result.exit_code > 0
+    assert "mutually exclusive" in result.output
+    transporter_ctor.assert_not_called()
+
+
+def test_cli_ssl_cert_without_key_rejected(
+    cli_runner: CliRunner,
+    sqlite_database: str,
+    mysql_credentials: MySQLCredentials,
+    tmp_path,
+    mocker: MockerFixture,
+) -> None:
+    transporter_ctor = mocker.patch("sqlite3_to_mysql.cli.SQLite3toMySQL", autospec=True)
+    cert_file = tmp_path / "client-cert.pem"
+    cert_file.write_text("fake")
+
+    result = cli_runner.invoke(
+        sqlite3mysql,
+        [
+            "-f",
+            sqlite_database,
+            "-d",
+            mysql_credentials.database,
+            "-u",
+            mysql_credentials.user,
+            "--mysql-ssl-cert",
+            str(cert_file),
+        ],
+    )
+
+    assert result.exit_code > 0
+    assert "must be provided together" in result.output
+    transporter_ctor.assert_not_called()
+
+
+def test_cli_ssl_key_without_cert_rejected(
+    cli_runner: CliRunner,
+    sqlite_database: str,
+    mysql_credentials: MySQLCredentials,
+    tmp_path,
+    mocker: MockerFixture,
+) -> None:
+    transporter_ctor = mocker.patch("sqlite3_to_mysql.cli.SQLite3toMySQL", autospec=True)
+    key_file = tmp_path / "client-key.pem"
+    key_file.write_text("fake")
+
+    result = cli_runner.invoke(
+        sqlite3mysql,
+        [
+            "-f",
+            sqlite_database,
+            "-d",
+            mysql_credentials.database,
+            "-u",
+            mysql_credentials.user,
+            "--mysql-ssl-key",
+            str(key_file),
+        ],
+    )
+
+    assert result.exit_code > 0
+    assert "must be provided together" in result.output
+    transporter_ctor.assert_not_called()
+
+
 def test_types_typed_dict_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     import typing
 
@@ -367,6 +560,213 @@ def test_rewrite_sqlite_view_functions_time_to_str_with_modifier_list() -> None:
     transformed = SQLite3toMySQL._rewrite_sqlite_view_functions(node)
     assert isinstance(transformed, exp.TimeToStr)
     assert isinstance(transformed.this, exp.UtcTimestamp)
+
+
+class TestSSLOptions:
+    """Tests for MySQL SSL certificate options."""
+
+    def _make_instance(
+        self,
+        sqlite_database: str,
+        mocker: MockerFixture,
+        **extra_kwargs: t.Any,
+    ) -> t.Tuple[SQLite3toMySQL, t.Dict[str, t.Any]]:
+        connect_kwargs: t.Dict[str, t.Any] = {}
+
+        class FakeCursor:
+            def execute(self, statement: t.Any) -> None:
+                del statement
+
+            def fetchone(self) -> t.Tuple[str, str]:
+                return ("version", "8.0.30")
+
+            def close(self) -> None:
+                pass
+
+        class FakeMySQLConnection:
+            def __init__(self) -> None:
+                self.database = None
+
+            def is_connected(self) -> bool:
+                return True
+
+            def cursor(self, *args: t.Any, **kwargs: t.Any) -> FakeCursor:
+                del args, kwargs
+                return FakeCursor()
+
+            def commit(self) -> None:
+                pass
+
+        def fake_connect(**kwargs: t.Any) -> FakeMySQLConnection:
+            connect_kwargs.update(kwargs)
+            return FakeMySQLConnection()
+
+        mocker.patch("sqlite3_to_mysql.transporter.mysql.connector.connect", side_effect=fake_connect)
+        mocker.patch("sqlite3_to_mysql.transporter.mysql.connector.MySQLConnection", FakeMySQLConnection)
+        mocker.patch(
+            "sqlite3_to_mysql.transporter.CharacterSet.get_default_collation",
+            return_value=("utf8mb4_unicode_ci", None),
+        )
+
+        kwargs: t.Dict[str, t.Any] = {
+            "sqlite_file": sqlite_database,
+            "mysql_user": "user",
+            "mysql_password": "pass",
+            "mysql_database": "demo",
+        }
+        kwargs.update(extra_kwargs)
+
+        return SQLite3toMySQL(**kwargs), connect_kwargs
+
+    def test_ssl_params_passed_to_mysql_connector(
+        self,
+        sqlite_database: str,
+        mocker: MockerFixture,
+    ) -> None:
+        instance, connect_kwargs = self._make_instance(
+            sqlite_database,
+            mocker,
+            mysql_ssl_ca="/path/to/ca.pem",
+            mysql_ssl_cert="/path/to/client-cert.pem",
+            mysql_ssl_key="/path/to/client-key.pem",
+        )
+
+        assert instance._mysql_ssl_ca == "/path/to/ca.pem"
+        assert instance._mysql_ssl_cert == "/path/to/client-cert.pem"
+        assert instance._mysql_ssl_key == "/path/to/client-key.pem"
+        assert connect_kwargs["ssl_ca"] == "/path/to/ca.pem"
+        assert connect_kwargs["ssl_cert"] == "/path/to/client-cert.pem"
+        assert connect_kwargs["ssl_key"] == "/path/to/client-key.pem"
+        assert connect_kwargs["ssl_verify_cert"] is True
+
+    def test_ssl_params_default_to_none(
+        self,
+        sqlite_database: str,
+        mocker: MockerFixture,
+    ) -> None:
+        instance, connect_kwargs = self._make_instance(sqlite_database, mocker)
+
+        assert instance._mysql_ssl_ca is None
+        assert instance._mysql_ssl_cert is None
+        assert instance._mysql_ssl_key is None
+        assert connect_kwargs["ssl_ca"] is None
+        assert connect_kwargs["ssl_cert"] is None
+        assert connect_kwargs["ssl_key"] is None
+        assert connect_kwargs["ssl_verify_cert"] is False
+
+    def test_ssl_ca_only(
+        self,
+        sqlite_database: str,
+        mocker: MockerFixture,
+    ) -> None:
+        instance, connect_kwargs = self._make_instance(
+            sqlite_database,
+            mocker,
+            mysql_ssl_ca="/path/to/ca.pem",
+        )
+
+        assert instance._mysql_ssl_ca == "/path/to/ca.pem"
+        assert instance._mysql_ssl_cert is None
+        assert instance._mysql_ssl_key is None
+        assert connect_kwargs["ssl_ca"] == "/path/to/ca.pem"
+        assert connect_kwargs["ssl_verify_cert"] is True
+
+    def test_ssl_cert_and_key_without_ca(
+        self,
+        sqlite_database: str,
+        mocker: MockerFixture,
+    ) -> None:
+        instance, connect_kwargs = self._make_instance(
+            sqlite_database,
+            mocker,
+            mysql_ssl_cert="/path/to/client-cert.pem",
+            mysql_ssl_key="/path/to/client-key.pem",
+        )
+
+        assert instance._mysql_ssl_ca is None
+        assert instance._mysql_ssl_cert == "/path/to/client-cert.pem"
+        assert instance._mysql_ssl_key == "/path/to/client-key.pem"
+        assert connect_kwargs["ssl_ca"] is None
+        assert connect_kwargs["ssl_cert"] == "/path/to/client-cert.pem"
+        assert connect_kwargs["ssl_key"] == "/path/to/client-key.pem"
+        assert connect_kwargs["ssl_verify_cert"] is False
+
+    def test_ssl_empty_strings_treated_as_none(
+        self,
+        sqlite_database: str,
+        mocker: MockerFixture,
+    ) -> None:
+        instance, connect_kwargs = self._make_instance(
+            sqlite_database,
+            mocker,
+            mysql_ssl_ca="",
+            mysql_ssl_cert="",
+            mysql_ssl_key="",
+        )
+
+        assert instance._mysql_ssl_ca is None
+        assert instance._mysql_ssl_cert is None
+        assert instance._mysql_ssl_key is None
+        assert connect_kwargs["ssl_ca"] is None
+        assert connect_kwargs["ssl_cert"] is None
+        assert connect_kwargs["ssl_key"] is None
+
+    def test_ssl_disabled_with_ssl_options_raises(
+        self,
+        sqlite_database: str,
+        mocker: MockerFixture,
+    ) -> None:
+        with pytest.raises(ValueError, match="Cannot use SSL certificate options when SSL is disabled"):
+            self._make_instance(
+                sqlite_database,
+                mocker,
+                mysql_ssl_ca="/path/to/ca.pem",
+                mysql_ssl_disabled=True,
+            )
+
+    def test_ssl_cert_without_key_raises(
+        self,
+        sqlite_database: str,
+        mocker: MockerFixture,
+    ) -> None:
+        with pytest.raises(ValueError, match="mysql_ssl_cert and mysql_ssl_key must be provided together"):
+            self._make_instance(
+                sqlite_database,
+                mocker,
+                mysql_ssl_cert="/path/to/client-cert.pem",
+            )
+
+    def test_ssl_key_without_cert_raises(
+        self,
+        sqlite_database: str,
+        mocker: MockerFixture,
+    ) -> None:
+        with pytest.raises(ValueError, match="mysql_ssl_cert and mysql_ssl_key must be provided together"):
+            self._make_instance(
+                sqlite_database,
+                mocker,
+                mysql_ssl_key="/path/to/client-key.pem",
+            )
+
+    def test_mysql_socket_with_ssl_options_raises(
+        self,
+        sqlite_database: str,
+        tmp_path,
+        mocker: MockerFixture,
+    ) -> None:
+        socket_file = tmp_path / "mysql.sock"
+        socket_file.write_text("")
+
+        with pytest.raises(
+            ValueError,
+            match="Cannot use SSL certificate options when connecting through a MySQL socket",
+        ):
+            self._make_instance(
+                sqlite_database,
+                mocker,
+                mysql_socket=str(socket_file),
+                mysql_ssl_ca="/path/to/ca.pem",
+            )
 
 
 def _make_transfer_stub(mocker: MockFixture) -> SQLite3toMySQL:

--- a/tests/unit/sqlite3_to_mysql_test.py
+++ b/tests/unit/sqlite3_to_mysql_test.py
@@ -199,6 +199,7 @@ def test_cli_skip_ssl_with_ssl_options_rejected(
 
     assert result.exit_code > 0
     assert "mutually exclusive" in result.output
+    assert "Error: Error:" not in result.output
     transporter_ctor.assert_not_called()
 
 
@@ -233,6 +234,7 @@ def test_cli_mysql_socket_with_ssl_options_rejected(
 
     assert result.exit_code > 0
     assert "mutually exclusive" in result.output
+    assert "Error: Error:" not in result.output
     transporter_ctor.assert_not_called()
 
 
@@ -291,6 +293,7 @@ def test_cli_ssl_cert_without_key_rejected(
 
     assert result.exit_code > 0
     assert "must be provided together" in result.output
+    assert "Error: Error:" not in result.output
     transporter_ctor.assert_not_called()
 
 
@@ -321,6 +324,7 @@ def test_cli_ssl_key_without_cert_rejected(
 
     assert result.exit_code > 0
     assert "must be provided together" in result.output
+    assert "Error: Error:" not in result.output
     transporter_ctor.assert_not_called()
 
 

--- a/tests/unit/sqlite3_to_mysql_test.py
+++ b/tests/unit/sqlite3_to_mysql_test.py
@@ -621,22 +621,29 @@ class TestSSLOptions:
     def test_ssl_params_passed_to_mysql_connector(
         self,
         sqlite_database: str,
+        tmp_path,
         mocker: MockerFixture,
     ) -> None:
+        ca_file = tmp_path / "ca.pem"
+        cert_file = tmp_path / "client-cert.pem"
+        key_file = tmp_path / "client-key.pem"
+        for cert_path in (ca_file, cert_file, key_file):
+            cert_path.write_text("fake")
+
         instance, connect_kwargs = self._make_instance(
             sqlite_database,
             mocker,
-            mysql_ssl_ca="/path/to/ca.pem",
-            mysql_ssl_cert="/path/to/client-cert.pem",
-            mysql_ssl_key="/path/to/client-key.pem",
+            mysql_ssl_ca=ca_file,
+            mysql_ssl_cert=cert_file,
+            mysql_ssl_key=key_file,
         )
 
-        assert instance._mysql_ssl_ca == "/path/to/ca.pem"
-        assert instance._mysql_ssl_cert == "/path/to/client-cert.pem"
-        assert instance._mysql_ssl_key == "/path/to/client-key.pem"
-        assert connect_kwargs["ssl_ca"] == "/path/to/ca.pem"
-        assert connect_kwargs["ssl_cert"] == "/path/to/client-cert.pem"
-        assert connect_kwargs["ssl_key"] == "/path/to/client-key.pem"
+        assert instance._mysql_ssl_ca == str(ca_file.resolve())
+        assert instance._mysql_ssl_cert == str(cert_file.resolve())
+        assert instance._mysql_ssl_key == str(key_file.resolve())
+        assert connect_kwargs["ssl_ca"] == str(ca_file.resolve())
+        assert connect_kwargs["ssl_cert"] == str(cert_file.resolve())
+        assert connect_kwargs["ssl_key"] == str(key_file.resolve())
         assert connect_kwargs["ssl_verify_cert"] is True
 
     def test_ssl_params_default_to_none(
@@ -657,38 +664,48 @@ class TestSSLOptions:
     def test_ssl_ca_only(
         self,
         sqlite_database: str,
+        tmp_path,
         mocker: MockerFixture,
     ) -> None:
+        ca_file = tmp_path / "ca.pem"
+        ca_file.write_text("fake")
+
         instance, connect_kwargs = self._make_instance(
             sqlite_database,
             mocker,
-            mysql_ssl_ca="/path/to/ca.pem",
+            mysql_ssl_ca=ca_file,
         )
 
-        assert instance._mysql_ssl_ca == "/path/to/ca.pem"
+        assert instance._mysql_ssl_ca == str(ca_file.resolve())
         assert instance._mysql_ssl_cert is None
         assert instance._mysql_ssl_key is None
-        assert connect_kwargs["ssl_ca"] == "/path/to/ca.pem"
+        assert connect_kwargs["ssl_ca"] == str(ca_file.resolve())
         assert connect_kwargs["ssl_verify_cert"] is True
 
     def test_ssl_cert_and_key_without_ca(
         self,
         sqlite_database: str,
+        tmp_path,
         mocker: MockerFixture,
     ) -> None:
+        cert_file = tmp_path / "client-cert.pem"
+        key_file = tmp_path / "client-key.pem"
+        cert_file.write_text("fake")
+        key_file.write_text("fake")
+
         instance, connect_kwargs = self._make_instance(
             sqlite_database,
             mocker,
-            mysql_ssl_cert="/path/to/client-cert.pem",
-            mysql_ssl_key="/path/to/client-key.pem",
+            mysql_ssl_cert=cert_file,
+            mysql_ssl_key=key_file,
         )
 
         assert instance._mysql_ssl_ca is None
-        assert instance._mysql_ssl_cert == "/path/to/client-cert.pem"
-        assert instance._mysql_ssl_key == "/path/to/client-key.pem"
+        assert instance._mysql_ssl_cert == str(cert_file.resolve())
+        assert instance._mysql_ssl_key == str(key_file.resolve())
         assert connect_kwargs["ssl_ca"] is None
-        assert connect_kwargs["ssl_cert"] == "/path/to/client-cert.pem"
-        assert connect_kwargs["ssl_key"] == "/path/to/client-key.pem"
+        assert connect_kwargs["ssl_cert"] == str(cert_file.resolve())
+        assert connect_kwargs["ssl_key"] == str(key_file.resolve())
         assert connect_kwargs["ssl_verify_cert"] is False
 
     def test_ssl_empty_strings_treated_as_none(
@@ -710,6 +727,32 @@ class TestSSLOptions:
         assert connect_kwargs["ssl_ca"] is None
         assert connect_kwargs["ssl_cert"] is None
         assert connect_kwargs["ssl_key"] is None
+
+    @pytest.mark.parametrize(
+        "ssl_kwargs,expected_message",
+        [
+            ({"mysql_ssl_ca": "missing-ca.pem"}, "MySQL SSL CA certificate file does not exist"),
+            (
+                {
+                    "mysql_ssl_cert": "missing-client-cert.pem",
+                    "mysql_ssl_key": "missing-client-key.pem",
+                },
+                "MySQL SSL certificate file does not exist",
+            ),
+        ],
+    )
+    def test_ssl_missing_files_raise(
+        self,
+        sqlite_database: str,
+        tmp_path,
+        mocker: MockerFixture,
+        ssl_kwargs: t.Dict[str, str],
+        expected_message: str,
+    ) -> None:
+        kwargs = {key: tmp_path / value for key, value in ssl_kwargs.items()}
+
+        with pytest.raises(FileNotFoundError, match=expected_message):
+            self._make_instance(sqlite_database, mocker, **kwargs)
 
     def test_ssl_disabled_with_ssl_options_raises(
         self,

--- a/tests/unit/sqlite3_to_mysql_test.py
+++ b/tests/unit/sqlite3_to_mysql_test.py
@@ -645,6 +645,7 @@ class TestSSLOptions:
         assert connect_kwargs["ssl_cert"] == str(cert_file.resolve())
         assert connect_kwargs["ssl_key"] == str(key_file.resolve())
         assert connect_kwargs["ssl_verify_cert"] is True
+        assert connect_kwargs["ssl_verify_identity"] is True
 
     def test_ssl_params_default_to_none(
         self,
@@ -660,6 +661,7 @@ class TestSSLOptions:
         assert connect_kwargs["ssl_cert"] is None
         assert connect_kwargs["ssl_key"] is None
         assert connect_kwargs["ssl_verify_cert"] is False
+        assert connect_kwargs["ssl_verify_identity"] is False
 
     def test_ssl_ca_only(
         self,
@@ -681,6 +683,7 @@ class TestSSLOptions:
         assert instance._mysql_ssl_key is None
         assert connect_kwargs["ssl_ca"] == str(ca_file.resolve())
         assert connect_kwargs["ssl_verify_cert"] is True
+        assert connect_kwargs["ssl_verify_identity"] is True
 
     def test_ssl_cert_and_key_without_ca(
         self,
@@ -707,6 +710,7 @@ class TestSSLOptions:
         assert connect_kwargs["ssl_cert"] == str(cert_file.resolve())
         assert connect_kwargs["ssl_key"] == str(key_file.resolve())
         assert connect_kwargs["ssl_verify_cert"] is False
+        assert connect_kwargs["ssl_verify_identity"] is False
 
     def test_ssl_empty_strings_treated_as_none(
         self,

--- a/tests/unit/sqlite3_to_mysql_test.py
+++ b/tests/unit/sqlite3_to_mysql_test.py
@@ -645,7 +645,6 @@ class TestSSLOptions:
         assert connect_kwargs["ssl_cert"] == str(cert_file.resolve())
         assert connect_kwargs["ssl_key"] == str(key_file.resolve())
         assert connect_kwargs["ssl_verify_cert"] is True
-        assert connect_kwargs["ssl_verify_identity"] is True
 
     def test_ssl_params_default_to_none(
         self,
@@ -661,7 +660,6 @@ class TestSSLOptions:
         assert connect_kwargs["ssl_cert"] is None
         assert connect_kwargs["ssl_key"] is None
         assert connect_kwargs["ssl_verify_cert"] is False
-        assert connect_kwargs["ssl_verify_identity"] is False
 
     def test_ssl_ca_only(
         self,
@@ -683,7 +681,6 @@ class TestSSLOptions:
         assert instance._mysql_ssl_key is None
         assert connect_kwargs["ssl_ca"] == str(ca_file.resolve())
         assert connect_kwargs["ssl_verify_cert"] is True
-        assert connect_kwargs["ssl_verify_identity"] is True
 
     def test_ssl_cert_and_key_without_ca(
         self,
@@ -710,7 +707,6 @@ class TestSSLOptions:
         assert connect_kwargs["ssl_cert"] == str(cert_file.resolve())
         assert connect_kwargs["ssl_key"] == str(key_file.resolve())
         assert connect_kwargs["ssl_verify_cert"] is False
-        assert connect_kwargs["ssl_verify_identity"] is False
 
     def test_ssl_empty_strings_treated_as_none(
         self,

--- a/tests/unit/types_test.py
+++ b/tests/unit/types_test.py
@@ -14,7 +14,7 @@ from sqlite3_to_mysql.types import SQLite3toMySQLAttributes, SQLite3toMySQLParam
 class TestTypes:
     def test_sqlite3_to_mysql_params_typing(self) -> None:
         """Test SQLite3toMySQLParams typing."""
-        # Create a valid params dict
+        # Create a runtime-valid params dict with all declared fields.
         params: SQLite3toMySQLParams = {
             "sqlite_file": "test.db",
             "sqlite_tables": ["table1", "table2"],
@@ -25,11 +25,11 @@ class TestTypes:
             "mysql_password": "password",
             "mysql_host": "localhost",
             "mysql_port": 3306,
-            "mysql_socket": "/var/run/mysqld/mysqld.sock",
+            "mysql_socket": None,
             "mysql_ssl_ca": "ca.pem",
             "mysql_ssl_cert": "client-cert.pem",
             "mysql_ssl_key": "client-key.pem",
-            "mysql_ssl_disabled": True,
+            "mysql_ssl_disabled": False,
             "chunk": 1000,
             "quiet": False,
             "log_file": "log.txt",
@@ -58,11 +58,11 @@ class TestTypes:
         assert params["mysql_password"] == "password"
         assert params["mysql_host"] == "localhost"
         assert params["mysql_port"] == 3306
-        assert params["mysql_socket"] == "/var/run/mysqld/mysqld.sock"
+        assert params["mysql_socket"] is None
         assert params["mysql_ssl_ca"] == "ca.pem"
         assert params["mysql_ssl_cert"] == "client-cert.pem"
         assert params["mysql_ssl_key"] == "client-key.pem"
-        assert params["mysql_ssl_disabled"] is True
+        assert params["mysql_ssl_disabled"] is False
         assert params["chunk"] == 1000
         assert params["quiet"] is False
         assert params["log_file"] == "log.txt"

--- a/tests/unit/types_test.py
+++ b/tests/unit/types_test.py
@@ -14,7 +14,7 @@ from sqlite3_to_mysql.types import SQLite3toMySQLAttributes, SQLite3toMySQLParam
 class TestTypes:
     def test_sqlite3_to_mysql_params_typing(self) -> None:
         """Test SQLite3toMySQLParams typing."""
-        # Create a runtime-valid params dict with all declared fields.
+        # Create a typing example with all declared fields and a valid SSL option combination.
         params: SQLite3toMySQLParams = {
             "sqlite_file": "test.db",
             "sqlite_tables": ["table1", "table2"],

--- a/tests/unit/types_test.py
+++ b/tests/unit/types_test.py
@@ -14,11 +14,11 @@ from sqlite3_to_mysql.types import SQLite3toMySQLAttributes, SQLite3toMySQLParam
 class TestTypes:
     def test_sqlite3_to_mysql_params_typing(self) -> None:
         """Test SQLite3toMySQLParams typing."""
-        # Create a typing example with all declared fields and a valid SSL option combination.
+        # Create a typing example with all declared fields and valid option combinations.
         params: SQLite3toMySQLParams = {
             "sqlite_file": "test.db",
             "sqlite_tables": ["table1", "table2"],
-            "exclude_sqlite_tables": ["skip_this"],
+            "exclude_sqlite_tables": None,
             "sqlite_views_as_tables": False,
             "without_foreign_keys": False,
             "mysql_user": "user",
@@ -51,7 +51,7 @@ class TestTypes:
         # Test that all fields are accessible
         assert params["sqlite_file"] == "test.db"
         assert params["sqlite_tables"] == ["table1", "table2"]
-        assert params["exclude_sqlite_tables"] == ["skip_this"]
+        assert params["exclude_sqlite_tables"] is None
         assert params["sqlite_views_as_tables"] is False
         assert params["without_foreign_keys"] is False
         assert params["mysql_user"] == "user"

--- a/tests/unit/types_test.py
+++ b/tests/unit/types_test.py
@@ -104,11 +104,11 @@ class TestTypes:
                 self._mysql_password = "password"
                 self._mysql_host = "localhost"
                 self._mysql_port = 3306
-                self._mysql_socket = "/var/run/mysqld/mysqld.sock"
+                self._mysql_socket = None
                 self._mysql_ssl_ca = "ca.pem"
                 self._mysql_ssl_cert = "client-cert.pem"
                 self._mysql_ssl_key = "client-key.pem"
-                self._mysql_ssl_disabled = True
+                self._mysql_ssl_disabled = False
                 self._chunk_size = 1000
                 self._quiet = False
                 self._logger = MagicMock(spec=Logger)
@@ -149,11 +149,11 @@ class TestTypes:
         assert instance._mysql_password == "password"
         assert instance._mysql_host == "localhost"
         assert instance._mysql_port == 3306
-        assert instance._mysql_socket == "/var/run/mysqld/mysqld.sock"
+        assert instance._mysql_socket is None
         assert instance._mysql_ssl_ca == "ca.pem"
         assert instance._mysql_ssl_cert == "client-cert.pem"
         assert instance._mysql_ssl_key == "client-key.pem"
-        assert instance._mysql_ssl_disabled is True
+        assert instance._mysql_ssl_disabled is False
         assert instance._chunk_size == 1000
         assert instance._quiet is False
         assert instance._log_file == "log.txt"

--- a/tests/unit/types_test.py
+++ b/tests/unit/types_test.py
@@ -26,6 +26,9 @@ class TestTypes:
             "mysql_host": "localhost",
             "mysql_port": 3306,
             "mysql_socket": "/var/run/mysqld/mysqld.sock",
+            "mysql_ssl_ca": "ca.pem",
+            "mysql_ssl_cert": "client-cert.pem",
+            "mysql_ssl_key": "client-key.pem",
             "mysql_ssl_disabled": True,
             "chunk": 1000,
             "quiet": False,
@@ -56,6 +59,9 @@ class TestTypes:
         assert params["mysql_host"] == "localhost"
         assert params["mysql_port"] == 3306
         assert params["mysql_socket"] == "/var/run/mysqld/mysqld.sock"
+        assert params["mysql_ssl_ca"] == "ca.pem"
+        assert params["mysql_ssl_cert"] == "client-cert.pem"
+        assert params["mysql_ssl_key"] == "client-key.pem"
         assert params["mysql_ssl_disabled"] is True
         assert params["chunk"] == 1000
         assert params["quiet"] is False
@@ -99,6 +105,9 @@ class TestTypes:
                 self._mysql_host = "localhost"
                 self._mysql_port = 3306
                 self._mysql_socket = "/var/run/mysqld/mysqld.sock"
+                self._mysql_ssl_ca = "ca.pem"
+                self._mysql_ssl_cert = "client-cert.pem"
+                self._mysql_ssl_key = "client-key.pem"
                 self._mysql_ssl_disabled = True
                 self._chunk_size = 1000
                 self._quiet = False
@@ -141,6 +150,9 @@ class TestTypes:
         assert instance._mysql_host == "localhost"
         assert instance._mysql_port == 3306
         assert instance._mysql_socket == "/var/run/mysqld/mysqld.sock"
+        assert instance._mysql_ssl_ca == "ca.pem"
+        assert instance._mysql_ssl_cert == "client-cert.pem"
+        assert instance._mysql_ssl_key == "client-key.pem"
         assert instance._mysql_ssl_disabled is True
         assert instance._chunk_size == 1000
         assert instance._quiet is False


### PR DESCRIPTION
This pull request adds support for connecting to MySQL using SSL certificates, improving security and flexibility for database migrations. It introduces new CLI options for specifying SSL certificate files, enforces proper validation and mutual exclusivity of SSL-related options, and adds comprehensive tests to verify SSL connection scenarios. Documentation is also updated to reflect these new features.

**MySQL SSL Connection Support**

* Added new CLI options: `--mysql-ssl-ca`, `--mysql-ssl-cert`, and `--mysql-ssl-key` for specifying paths to SSL certificate files when connecting to MySQL. These options are validated to ensure correct usage and mutual exclusivity with `--skip-ssl` and `--mysql-socket`. [[1]](diffhunk://#diff-dd015dec2b06171d27fb832d6d34a2ab9233f4d965899504d017afd7edd6e8fcR87-R104) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L63-R69) [[3]](diffhunk://#diff-bd548e7db9014f8f260e91e07e0cd7656294babd0f3fecabf215b561b9e11efcL31-R35)
* Updated the connection logic in `SQLite3toMySQL` to use the provided SSL certificate files and ensure they are only used when appropriate. [[1]](diffhunk://#diff-d7fdd70c87f12265c8c523bafe5dca1be203b4bf7ef4ad0162c56af59a1e2504R141-R154) [[2]](diffhunk://#diff-d7fdd70c87f12265c8c523bafe5dca1be203b4bf7ef4ad0162c56af59a1e2504R228-R231)

**Validation and Error Handling**

* Implemented validation to prevent incompatible combinations of SSL options (e.g., using `--skip-ssl` with SSL cert options, or using SSL certs with a Unix socket). Also ensures both cert and key must be provided together. [[1]](diffhunk://#diff-dd015dec2b06171d27fb832d6d34a2ab9233f4d965899504d017afd7edd6e8fcR229-R241) [[2]](diffhunk://#diff-d7fdd70c87f12265c8c523bafe5dca1be203b4bf7ef4ad0162c56af59a1e2504R141-R154)

**Documentation Updates**

* Updated `README.md` and `docs/README.rst` to document the new SSL options and clarify their usage and restrictions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L63-R69) [[2]](diffhunk://#diff-bd548e7db9014f8f260e91e07e0cd7656294babd0f3fecabf215b561b9e11efcL31-R35) [[3]](diffhunk://#diff-bd548e7db9014f8f260e91e07e0cd7656294babd0f3fecabf215b561b9e11efcL48-R51)

**Testing Enhancements**

* Added a pytest fixture to extract SSL certificate files from the MySQL Docker container for testing.
* Added functional tests to verify successful and unsuccessful SSL connection scenarios, including all valid combinations and expected failures when options are misused.

**Code Quality Improvements**

* Improved resource cleanup in tests by ensuring Docker clients and containers are properly closed and killed after tests. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R108-R129) [[2]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R251) [[3]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R263)

These changes collectively provide robust SSL support for MySQL connections, enhance security, and ensure reliability through thorough validation and testing.