### PR TITLE
feat: add support for MySQL 9.7 in tests and documentation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -505,6 +505,48 @@ jobs:
             experimental: true
             py: "3.14t"
 
+          - toxenv: "python3.9"
+            db: "mysql:9.7"
+            legacy_db: 0
+            experimental: true
+            py: "3.9"
+
+          - toxenv: "python3.10"
+            db: "mysql:9.7"
+            legacy_db: 0
+            experimental: true
+            py: "3.10"
+
+          - toxenv: "python3.11"
+            db: "mysql:9.7"
+            legacy_db: 0
+            experimental: true
+            py: "3.11"
+
+          - toxenv: "python3.12"
+            db: "mysql:9.7"
+            legacy_db: 0
+            experimental: true
+            py: "3.12"
+
+          - toxenv: "python3.13"
+            db: "mysql:9.7"
+            legacy_db: 0
+            experimental: true
+            py: "3.13"
+
+          - toxenv: "python3.14"
+            db: "mysql:9.7"
+            legacy_db: 0
+            experimental: false
+            py: "3.14"
+
+          - toxenv: "python3.14t"
+            db: "mysql:9.7"
+            legacy_db: 0
+            experimental: true
+            py: "3.14t"
+
     continue-on-error: ${{ matrix.experimental }}
     services:
       mysql:
@@ -551,7 +593,7 @@ jobs:
           set -e
           
           case "$DB" in
-            'mysql:8.0'|'mysql:8.4')
+            'mysql:8.0'|'mysql:8.4'|'mysql:9.7')
               mysql -h127.0.0.1 -uroot -e "SET GLOBAL local_infile=on"
               docker cp mysqld:/var/lib/mysql/public_key.pem "${HOME}"
 
@@ -675,7 +717,7 @@ jobs:
               nopass_caching_sha2 IDENTIFIED WITH "caching_sha2_password"
               PASSWORD EXPIRE NEVER;
               GRANT RELOAD ON *.* TO user_caching_sha2;'
-          elif [ "$DB" == 'mysql:8.4' ]; then
+          elif [[ "$DB" == 'mysql:8.4' || "$DB" == 'mysql:9.7' ]]; then
             WITH_PLUGIN='with caching_sha2_password'
             USER_CREATION_COMMANDS='
               CREATE USER

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,12 +13,14 @@ interactions related to the project.
 
 Ensuring backward compatibility is an imperative requirement.
 
-Currently, the tool supports Python versions 3.9, 3.10, 3.11, 3.12, 3.13, and 3.14.
+Currently, the tool supports Python versions 3.9, 3.10, 3.11, 3.12, 3.13, and 3.14, including
+3.14t (free-threaded).
 
 ## MySQL version support
 
-This tool is intended to fully support MySQL versions 5.5, 5.6, 5.7, and 8.0, including major forks like MariaDB.
-We should prioritize and be dedicated to maintaining compatibility with these versions for a smooth user experience.
+This tool is intended to fully support MySQL versions 5.5, 5.6, 5.7, 8.0, 8.4, and 9.7, including
+major forks like MariaDB. We should prioritize and be dedicated to maintaining compatibility with these versions for a
+smooth user experience.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/sqlite3-to-mysql?logo=pypi&label=PyPI%20downloads)](https://pypistats.org/packages/sqlite3-to-mysql)
 [![Homebrew Formula Downloads](https://img.shields.io/homebrew/installs/dm/sqlite3-to-mysql?logo=homebrew&label=Homebrew%20downloads)](https://formulae.brew.sh/formula/sqlite3-to-mysql)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/sqlite3-to-mysql?logo=python)](https://pypi.org/project/sqlite3-to-mysql/)
-[![MySQL Support](https://img.shields.io/static/v1?logo=mysql&label=MySQL&message=5.5+|+5.6+|+5.7+|+8.0+|+8.4&color=2b5d80)](https://github.com/techouse/sqlite3-to-mysql/actions/workflows/test.yml)
+[![MySQL Support](https://img.shields.io/static/v1?logo=mysql&label=MySQL&message=5.5+|+5.6+|+5.7+|+8.0+|+8.4+|+9.7&color=2b5d80)](https://github.com/techouse/sqlite3-to-mysql/actions/workflows/test.yml)
 [![MariaDB Support](https://img.shields.io/static/v1?logo=mariadb&label=MariaDB&message=5.5+|+10.0+|+10.6+|+10.11+|+11.4+|+11.8&color=C0765A)](https://github.com/techouse/sqlite3-to-mysql/actions/workflows/test.yml)
 [![GitHub license](https://img.shields.io/github/license/techouse/sqlite3-to-mysql)](https://github.com/techouse/sqlite3-to-mysql/blob/master/LICENSE)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?logo=contributorcovenant)](CODE-OF-CONDUCT.md)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,7 +66,7 @@ Indices and tables
    :target: https://formulae.brew.sh/formula/sqlite3-to-mysql
 .. |PyPI - Python Version| image:: https://img.shields.io/pypi/pyversions/sqlite3-to-mysql?logo=python
    :target: https://pypi.org/project/sqlite3-to-mysql/
-.. |MySQL Support| image:: https://img.shields.io/static/v1?logo=mysql&label=MySQL&message=5.5+%7C+5.6+%7C+5.7+%7C+8.0+%7C+8.4&color=2b5d80
+.. |MySQL Support| image:: https://img.shields.io/static/v1?logo=mysql&label=MySQL&message=5.5+%7C+5.6+%7C+5.7+%7C+8.0+%7C+8.4+%7C+9.7&color=2b5d80
    :target: https://github.com/techouse/sqlite3-to-mysql/actions/workflows/test.yml
 .. |MariaDB Support| image:: https://img.shields.io/static/v1?logo=mariadb&label=MariaDB&message=5.5+%7C+10.0+%7C+10.6+%7C+10.11+%7C+11.4+%7C+11.8&color=C0765A
    :target: https://github.com/techouse/sqlite3-to-mysql/actions/workflows/test.yml

--- a/tests/unit/mysql_utils_test.py
+++ b/tests/unit/mysql_utils_test.py
@@ -25,6 +25,7 @@ class TestMySQLUtils:
             ("5.7.8", Version("5.7.8")),
             ("8.0.0", Version("8.0.0")),
             ("9.0.0", Version("9.0.0")),
+            ("9.7.0", Version("9.7.0")),
             ("10.2.6-mariadb", Version("10.2.6")),
             ("10.2.7-mariadb", Version("10.2.7")),
             ("11.4.0-mariadb", Version("11.4.0")),
@@ -40,6 +41,7 @@ class TestMySQLUtils:
             ("5.7.8", True),
             ("8.0.0", True),
             ("9.0.0", True),
+            ("9.7.0", True),
             ("10.2.6-mariadb", False),
             ("10.2.7-mariadb", True),
             ("11.4.0-mariadb", True),
@@ -56,6 +58,7 @@ class TestMySQLUtils:
             ("8.0.18", False),
             ("8.0.19", True),
             ("9.0.0", True),
+            ("9.7.0", True),
             ("10.2.6-mariadb", False),
             ("10.2.7-mariadb", False),
             ("11.4.0-mariadb", False),
@@ -71,6 +74,7 @@ class TestMySQLUtils:
             ("5.5.0", False),
             ("5.6.0", True),
             ("8.0.0", True),
+            ("9.7.0", True),
             ("10.0.4-mariadb", False),
             ("10.0.5-mariadb", True),
             ("10.2.6-mariadb", True),
@@ -221,6 +225,7 @@ class TestMySQLUtils:
             ("8.0.12", False),
             ("8.0.13", True),
             ("8.0.13-8ubuntu1", True),
+            ("9.7.0", True),
             ("5.7.44", False),
         ],
     )
@@ -248,6 +253,7 @@ class TestMySQLUtils:
             ("5.6.4", False),
             ("5.6.5", True),
             ("5.6.5-ps-log", True),
+            ("9.7.0", True),
             ("5.5.62", False),
         ],
     )
@@ -274,6 +280,7 @@ class TestMySQLUtils:
             ("5.6.3", False),
             ("5.6.4", True),
             ("5.7.44-0ubuntu0.18.04.1", True),
+            ("9.7.0", True),
         ],
     )
     def test_fractional_seconds_mysql(self, ver: str, expected: bool) -> None:


### PR DESCRIPTION
This pull request expands support for newer MySQL and Python versions and updates documentation and tests accordingly. The main focus is on adding MySQL 9.7 and Python 3.14t (free-threaded) to the supported environments, ensuring comprehensive compatibility and testing coverage.

**Expanded MySQL and Python version support:**

* Added MySQL 9.7 to the supported/tested versions in the GitHub Actions workflow (`.github/workflows/test.yml`), documentation (`README.md`, `docs/index.rst`, `CONTRIBUTING.md`), and test logic. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R508-R549) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L554-R596) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L678-R720) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5) [[5]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534L69-R69) [[6]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L16-R23)
* Included Python 3.14t (free-threaded) in the CI matrix and documentation, ensuring compatibility and future-proofing for Python's new threading model. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R508-R549) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L16-R23)

**Testing and compatibility improvements:**

* Updated test cases in `tests/unit/mysql_utils_test.py` to cover MySQL 9.7 for version parsing, feature support, and compatibility checks. [[1]](diffhunk://#diff-70ecc0cf7ca5429c9308cfab6d1d949f8a9a6fdbc2723f0aff01bdbc3b22fcbaR28) [[2]](diffhunk://#diff-70ecc0cf7ca5429c9308cfab6d1d949f8a9a6fdbc2723f0aff01bdbc3b22fcbaR44) [[3]](diffhunk://#diff-70ecc0cf7ca5429c9308cfab6d1d949f8a9a6fdbc2723f0aff01bdbc3b22fcbaR61) [[4]](diffhunk://#diff-70ecc0cf7ca5429c9308cfab6d1d949f8a9a6fdbc2723f0aff01bdbc3b22fcbaR77) [[5]](diffhunk://#diff-70ecc0cf7ca5429c9308cfab6d1d949f8a9a6fdbc2723f0aff01bdbc3b22fcbaR228) [[6]](diffhunk://#diff-70ecc0cf7ca5429c9308cfab6d1d949f8a9a6fdbc2723f0aff01bdbc3b22fcbaR256) [[7]](diffhunk://#diff-70ecc0cf7ca5429c9308cfab6d1d949f8a9a6fdbc2723f0aff01bdbc3b22fcbaR283)
* Adjusted MySQL setup scripts in the CI workflow to handle MySQL 9.7-specific configuration and authentication logic. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L554-R596) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L678-R720)

**Documentation updates:**

* Updated badges and support statements in `README.md`, `docs/index.rst`, and `CONTRIBUTING.md` to reflect support for MySQL 9.7 and Python 3.14t. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5) [[2]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534L69-R69) [[3]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L16-R23)